### PR TITLE
Fix to "Wrong"

### DIFF
--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -129,7 +129,7 @@
 	"Theatre.Emote.Lazy" : "Lazy",
 	"Theatre.Emote.Ambitious" : "Ambitious",
 	"Theatre.Emote.Correct" : "Correct",
-	"Theatre.Emote.Correct" : "Wrong",
+	"Theatre.Emote.Wrong" : "Wrong",
 
 	"Theatre.Flyin.Label" : "Fly-In",
 	"Theatre.Flyin.Typewriter" : "Typewriter",


### PR DESCRIPTION
"Wrong" was using a duplicated key for "Theatre.Emote.Correct", changed key to "Theatre.Emote.Wrong"