### PR TITLE
Expand Canvas

### DIFF
--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -2041,7 +2041,8 @@ class Theatre {
 
 		let app = new PIXI.Application({ 
 			transparent: true , 
-			antialias: true
+			antialias: true ,
+			width: document.body.offsetWidth;
 		});
 
 		let canvas = app.view; 


### PR DESCRIPTION
Sets the canvas that theatre inserts are drawn onto to be the same size as the document.

With testing this appears to fix the issue #32 I wrote up.