### PR TITLE
Fix emotion thumbnail ratio

### DIFF
--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -1944,8 +1944,8 @@ class Theatre {
 			app.stage.height = scaledHeight; 
 
 			app.stage.addChild(sprite); 
-			app.stage.scale.x = ratio*2; 
-			app.stage.scale.y = ratio*2; 
+			app.stage.scale.x = ratio;
+			app.stage.scale.y = ratio;
 			app.stage.y = 70 - (portHeight*ratio)/2; 
 		} else {
 			// scale portHeight to 200px, assign width as a fraction
@@ -1956,8 +1956,8 @@ class Theatre {
 			app.stage.height = scaledHeight; 
 
 			app.stage.addChild(sprite); 
-			app.stage.scale.x = ratio*2; 
-			app.stage.scale.y = ratio*2; 
+			app.stage.scale.x = ratio;
+			app.stage.scale.y = ratio;
 			app.stage.x = 70 - (portWidth*ratio*2)/2; 
 		}
 


### PR DESCRIPTION
Fix thumbnail image for emotion selection area in sidebar

A thumbnail is displayed on mouse hover when selecting emotions.
This thumbnail is only drawn in the upper left 1/4 of the image.

I found out that the image had been scaled, adjusted in proportion, and then stretched to twice its original size, both horizontally and vertically. So, I stopped stretching the image so that the whole image could be seen.

before | after 
 --- | ---
![スクリーンショット 2021-09-19 235614](https://user-images.githubusercontent.com/2664198/134929740-d37e52fb-e3aa-4af4-a7e3-7f05047c945a.png) |![スクリーンショット 2021-09-19 235802](https://user-images.githubusercontent.com/2664198/134929792-7e8b44ae-2c24-41c2-a531-28807a096b94.png) 



