### PR TITLE
Add a new setting for remove the label from the header sheet of the actor

### DIFF
--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -454,6 +454,15 @@ class Theatre {
 		  	default: false
 		});
 
+		game.settings.register(Theatre.SETTINGS, "removeLabelSheetHeader", {
+			name: "Theatre.UI.Settings.removeLabelSheetHeader",
+		  	hint: "Theatre.UI.Settings.removeLabelSheetHeaderHint",
+		  	scope: "world",
+		  	config: true,
+		  	type: Boolean,
+		  	default: false
+		});
+
 		// Load in default settings (theatreStyle is loaded on HTML Injection)
 		this.settings.decayMin = (game.settings.get(Theatre.SETTINGS,"textDecayMin")||30)*1000; 
 		this.settings.decayRate = (game.settings.get(Theatre.SETTINGS,"textDecayRate")||1)*1000; 
@@ -7873,11 +7882,11 @@ class Theatre {
 	 *
 	 * @params ev (Event) : The event that triggered adding to the NavBar staging area.
 	 */
-	static onAddToNavBar(ev,actorSheet) {
+	static onAddToNavBar(ev,actorSheet,removeLabelSheetHeader) {
 		if (Theatre.DEBUG) console.log("Click Event on Add to NavBar!!",actorSheet,actorSheet.actor,actorSheet.position); 
 		const actor = actorSheet.object.data; 
-		const addLabel = game.i18n.localize("Theatre.UI.Config.AddToStage");
-		const removeLabel = game.i18n.localize("Theatre.UI.Config.RemoveFromStage");
+		const addLabel = removeLabelSheetHeader ? "" : game.i18n.localize("Theatre.UI.Config.AddToStage");
+		const removeLabel = removeLabelSheetHeader ? "" : game.i18n.localize("Theatre.UI.Config.RemoveFromStage");
 		let newText;
 		if (Theatre.isActorStaged(actor)) {
 			Theatre.removeFromNavBar(actor)
@@ -7886,7 +7895,7 @@ class Theatre {
 			Theatre.addToNavBar(actor); 
 			newText = removeLabel;
 		}
-		ev.currentTarget.innerHTML = `<i class="fas fa-theater-masks"></i>${newText}`
+		ev.currentTarget.innerHTML = Theatre.isActorStaged(actor) ? `<i class="fas fa-theater-masks"></i>${newText}` :  `<i class="fas fa-mask"></i>${newText}`;
 	}
 
 	static _getTheatreId(actor) {

--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -126,12 +126,13 @@ Handlebars.registerHelper("resprop", function(propPath, hash) {
  */
  Hooks.on("getActorSheetHeaderButtons",(app,buttons)=>{
   let theatreButtons = []
+  let removeLabelSheetHeader = game.settings.get(Theatre.SETTINGS,"removeLabelSheetHeader");
   if (app.object.isOwner) {
     // only prototype actors
     if (!app.object.token) {
       
       theatreButtons.push({
-          label: "Theatre.UI.Config.Theatre",
+          label: removeLabelSheetHeader ? "" : "Theatre.UI.Config.Theatre",
           class: "configure-theatre",
           icon: "fas fa-user-edit",
           onclick: ev => Theatre.onConfigureInsert(ev, app.object.sheet)
@@ -139,11 +140,11 @@ Handlebars.registerHelper("resprop", function(propPath, hash) {
       
     }
     theatreButtons.push({
-        label: Theatre.isActorStaged(app.object.data) ? "Theatre.UI.Config.RemoveFromStage" : "Theatre.UI.Config.AddToStage",
+        label: removeLabelSheetHeader ? "" : (Theatre.isActorStaged(app.object.data) ? "Theatre.UI.Config.RemoveFromStage" : "Theatre.UI.Config.AddToStage"),
         class: "add-to-theatre-navbar",
-        icon: "fas fa-theater-masks",
+        icon: (Theatre.isActorStaged(app.object.data) ? "fas fa-theater-masks" : "fas fa-mask"),
         onclick: ev => {
-          Theatre.onAddToNavBar(ev, app.object.sheet);
+          Theatre.onAddToNavBar(ev, app.object.sheet, removeLabelSheetHeader);
         }
       })
   }

--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -63,6 +63,9 @@
 	"Theatre.UI.Settings.nameFontSizeHint": "Sets the size of the name font. Note that the sizes may be different depending on your display or font choice. Using huge sizes is not recommended.",
 	"Theatre.UI.Settings.autoHideBottom": "Auto Hide Bottom",
 	"Theatre.UI.Settings.autoHideBottomHint": "Hide bottom UI(player&hotbar) when actor shows on stage.",
+	"Theatre.UI.Settings.removeLabelSheetHeader": "Remove label from the header character sheet",
+	"Theatre.UI.Settings.removeLabelSheetHeaderHint": "Remove label from the header character sheet, Useful for little screen and mobile",
+	
 	
 	"Theatre.MOTD.Header" : "Theatre Notification",
 	"Theatre.MOTD.OldVersion" : "Theatre is currently out of date, please have the GM update theatre in the setup screen.",


### PR DESCRIPTION
Add a new setting for remove the label from the header sheet of the actor.
I found this is very useful in little screen and mobile, when many module are going to populate the header sheet of the actor.