### PR TITLE
New module setting: Show Macro Hotbar When Stage is Suppressed

### DIFF
--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -454,6 +454,15 @@ class Theatre {
 		  	default: false
 		});
 
+		game.settings.register(Theatre.SETTINGS, "supressMacroHotbar", {
+			name: "Theatre.UI.Settings.suppressMacroHotbar",
+		  	hint: "",
+		  	scope: "world",
+		  	config: true,
+		  	type: Boolean,
+		  	default: false
+		});
+
 		game.settings.register(Theatre.SETTINGS, "removeLabelSheetHeader", {
 			name: "Theatre.UI.Settings.removeLabelSheetHeader",
 		  	hint: "Theatre.UI.Settings.removeLabelSheetHeaderHint",

--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -2090,11 +2090,6 @@ class Theatre {
 				if (Theatre.DEBUG) this._updateTheatreDebugInfo(insert); 
 				// PIXI.v6 The renderer should not clear the canvas on rendering
 				this.pixiCTX.renderer.render(insert.dockContainer, { clear: false });
-				let autoHide = game.settings.get(Theatre.SETTINGS,"autoHideBottom");
-				if (autoHide == true){
-					$('#players').hide();
-					$('#hotbar').hide();
-				}
 			}
 			else {
 				console.log("INSERT HAS NO CONTAINER! _renderTheatre : HOT-EJECTING it! ",insert); 

--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -454,7 +454,7 @@ class Theatre {
 		  	default: false
 		});
 
-		game.settings.register(Theatre.SETTINGS, "supressMacroHotbar", {
+		game.settings.register(Theatre.SETTINGS, "suppressMacroHotbar", {
 			name: "Theatre.UI.Settings.suppressMacroHotbar",
 		  	hint: "",
 		  	scope: "world",

--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -599,7 +599,7 @@ Hooks.on("getActorDirectoryEntryContext", async (html, options) => {
  * Hide player list (and macro hotbar) when stage is active (and not suppressed)
  */
 Hooks.on("theatreDockActive", insertCount => {
-  if (!game.settings.get(Theatre.SETTINGS,"autoHideBottom")) return;
+  if (!game.settings.get(Theatre.SETTINGS, "autoHideBottom")) return;
   if (!insertCount) return;
   
   $('#players').hide();
@@ -610,7 +610,8 @@ Hooks.on("theatreDockActive", insertCount => {
  * Hide/show macro hotbar when stage is suppressed
  */
 Hooks.on("theatreSuppression", suppressed => {
-  if (!game.settings.get(Theatre.SETTINGS,"autoHideBottom")) return;
+  if (!game.settings.get(Theatre.SETTINGS, "autoHideBottom")) return;
+  if (!game.settings.get(Theatre.SETTINGS, "suppressMacroHotbar")) return;
   if (!theatre.dockActive) return;
 
   if (suppressed) $(`#hotbar`).show();

--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -594,3 +594,25 @@ Hooks.on("getActorDirectoryEntryContext", async (html, options) => {
     callback: target => Theatre.removeFromNavBar(getActorData(target))
   });
 });
+
+/**
+ * Hide player list (and macro hotbar) when stage is active (and not suppressed)
+ */
+Hooks.on("theatreDockActive", insertCount => {
+  if (!game.settings.get(Theatre.SETTINGS,"autoHideBottom")) return;
+  if (!insertCount) return;
+  
+  $('#players').hide();
+  if (!theatre.isSuppressed) $('#hotbar').hide();
+});
+
+/**
+ * Hide/show macro hotbar when stage is suppressed
+ */
+Hooks.on("theatreSuppression", suppressed => {
+  if (!game.settings.get(Theatre.SETTINGS,"autoHideBottom")) return;
+  if (!theatre.dockActive) return;
+
+  if (suppressed) $(`#hotbar`).show();
+  else $(`#hotbar`).hide();
+});

--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -63,6 +63,7 @@
 	"Theatre.UI.Settings.nameFontSizeHint": "Sets the size of the name font. Note that the sizes may be different depending on your display or font choice. Using huge sizes is not recommended.",
 	"Theatre.UI.Settings.autoHideBottom": "Auto Hide Bottom",
 	"Theatre.UI.Settings.autoHideBottomHint": "Hide bottom UI(player&hotbar) when actor shows on stage.",
+	"Theatre.UI.Settings.suppressMacroHotbar": "Show Macro Hotbar When Stage is Suppressed",
 	"Theatre.UI.Settings.removeLabelSheetHeader": "Remove label from the header character sheet",
 	"Theatre.UI.Settings.removeLabelSheetHeaderHint": "Remove label from the header character sheet, Useful for little screen and mobile",
 	


### PR DESCRIPTION
Moves the hiding of the players list and macro hotbar out of the render loop (the elements do not need to be re-hidden constantly).

When the stage is suppressed using the Suppress Theatre button, the macro hotbar will be shown, allowing access to macros while the stage is active.

This new feature still requires the "Auto Hide Bottom" module setting to be enabled and requires a newly added module setting to be enabled.