### PR TITLE
V1.20.0 Update for Foundry v9

### DIFF
--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -444,39 +444,17 @@ class Theatre {
 				// NOOP
 			}
 		});
-		
-		game.settings.register(Theatre.SETTINGS, "autoHideBottom", {
-			name: "Theatre.UI.Settings.autoHideBottom",
-		  	hint: "Theatre.UI.Settings.autoHideBottomHint",
-		  	scope: "world",
-		  	config: true,
-		  	type: Boolean,
-		  	default: false
-		});
 
-		game.settings.register(Theatre.SETTINGS, "suppressMacroHotbar", {
-			name: "Theatre.UI.Settings.suppressMacroHotbar",
-		  	hint: "",
-		  	scope: "world",
-		  	config: true,
-		  	type: Boolean,
-		  	default: false
-		});
-
-		game.settings.register(Theatre.SETTINGS, "removeLabelSheetHeader", {
-			name: "Theatre.UI.Settings.removeLabelSheetHeader",
-		  	hint: "Theatre.UI.Settings.removeLabelSheetHeaderHint",
-		  	scope: "world",
-		  	config: true,
-		  	type: Boolean,
-		  	default: false
-		});
 
 		// Load in default settings (theatreStyle is loaded on HTML Injection)
 		this.settings.decayMin = (game.settings.get(Theatre.SETTINGS,"textDecayMin")||30)*1000; 
 		this.settings.decayRate = (game.settings.get(Theatre.SETTINGS,"textDecayRate")||1)*1000; 
 		this.settings.motdNewInfo = game.settings.get(Theatre.SETTINGS,"motdNewInfo")||1; 
 
+		//Add localization to keybinding
+		let keybinding = game.keybindings.actions.get("theatre.theatreToggleTokenStaged");
+        keybinding.name = game.i18n.localize("Theatre.Keybindings.Stage.Name");
+        keybinding.hint = game.i18n.localize("Theatre.Keybindings.Stage.Hint");
 	}
 
 	/**
@@ -2223,8 +2201,6 @@ class Theatre {
 			insert.dockContainer = null; 
 			let idx = this.portraitDocks.findIndex(e => e.imgId == imgId);
 			this.portraitDocks.splice(idx,1); 
-			$('#players').show();
-			$('#hotbar').show();
 		}
 		// force a render update
 		//app.render(); 
@@ -6646,8 +6622,6 @@ class Theatre {
 					Theatre.instance.textFont = "SignikaBold"; 
 					Theatre.instance.fontWeight = "normal";
 					Theatre.FONTS = [
-						"Caslon",
-						"CaslonAntique",
 						"SignikaBold", 
 						"Riffic",
 						"IronSans",
@@ -6720,8 +6694,6 @@ class Theatre {
 					Theatre.instance.textFont = "SignikaBold"; 
 					Theatre.instance.fontWeight = "normal"; 
 					Theatre.FONTS = [
-						"Caslon",
-						"CaslonAntique",
 						"SignikaBold", 
 						"Riffic",
 						"LinLibertine",
@@ -7886,11 +7858,11 @@ class Theatre {
 	 *
 	 * @params ev (Event) : The event that triggered adding to the NavBar staging area.
 	 */
-	static onAddToNavBar(ev,actorSheet,removeLabelSheetHeader) {
+	static onAddToNavBar(ev,actorSheet) {
 		if (Theatre.DEBUG) console.log("Click Event on Add to NavBar!!",actorSheet,actorSheet.actor,actorSheet.position); 
 		const actor = actorSheet.object.data; 
-		const addLabel = removeLabelSheetHeader ? "" : game.i18n.localize("Theatre.UI.Config.AddToStage");
-		const removeLabel = removeLabelSheetHeader ? "" : game.i18n.localize("Theatre.UI.Config.RemoveFromStage");
+		const addLabel = game.i18n.localize("Theatre.UI.Config.AddToStage");
+		const removeLabel = game.i18n.localize("Theatre.UI.Config.RemoveFromStage");
 		let newText;
 		if (Theatre.isActorStaged(actor)) {
 			Theatre.removeFromNavBar(actor)
@@ -7899,7 +7871,7 @@ class Theatre {
 			Theatre.addToNavBar(actor); 
 			newText = removeLabel;
 		}
-		ev.currentTarget.innerHTML = Theatre.isActorStaged(actor) ? `<i class="fas fa-theater-masks"></i>${newText}` :  `<i class="fas fa-mask"></i>${newText}`;
+		ev.currentTarget.innerHTML = `<i class="fas fa-theater-masks"></i>${newText}`
 	}
 
 	static _getTheatreId(actor) {
@@ -8594,6 +8566,22 @@ class Theatre {
 			return Theatre.FLYIN_ANIMS[name].func; 
 		else
 			return Theatre.FLYIN_ANIMS["typewriter"].func; 
+	}
+
+	/**
+	 * Adds/Removes the selected token(s) from the stage.
+	 * 
+	 */
+	static toggleSelectedTokens() {
+		if (canvas.tokens.controlled) {
+			for (let token of canvas.tokens.controlled) {
+				if(Theatre.isActorStaged(token.actor.data)) {
+					Theatre.removeFromNavBar(token.actor.data);
+				} else {
+					Theatre.addToNavBar(token.actor.data);
+				}
+			} 
+		}
 	}
 
 }

--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -61,12 +61,6 @@
 	"Theatre.UI.Settings.nameFontHint": "Put in the name of the font you want to use. If the font exists in Theatre, it can be used. Requires actors to re-stage or for the GM to resync.",
 	"Theatre.UI.Settings.nameFontSize": "Actor Name Size (Experimental)",
 	"Theatre.UI.Settings.nameFontSizeHint": "Sets the size of the name font. Note that the sizes may be different depending on your display or font choice. Using huge sizes is not recommended.",
-	"Theatre.UI.Settings.autoHideBottom": "Auto Hide Bottom",
-	"Theatre.UI.Settings.autoHideBottomHint": "Hide bottom UI(player&hotbar) when actor shows on stage.",
-	"Theatre.UI.Settings.suppressMacroHotbar": "Show Macro Hotbar When Stage is Suppressed",
-	"Theatre.UI.Settings.removeLabelSheetHeader": "Remove label from the header character sheet",
-	"Theatre.UI.Settings.removeLabelSheetHeaderHint": "Remove label from the header character sheet, Useful for little screen and mobile",
-	
 	
 	"Theatre.MOTD.Header" : "Theatre Notification",
 	"Theatre.MOTD.OldVersion" : "Theatre is currently out of date, please have the GM update theatre in the setup screen.",
@@ -168,5 +162,8 @@
 	"Theatre.Standing.None" : "None",
 
 	"Theatre.Other" : "Other",
-	"Theatre.NotYet" : "Not yet implemented"
+	"Theatre.NotYet" : "Not yet implemented",
+
+	"Theatre.Keybindings.Stage.Name": "Toggle Selected Tokens to Stage",
+	"Theatre.Keybindings.Stage.Hint": "Keybinding to toggle all selected tokens on and off the stage."
 }

--- a/module.json
+++ b/module.json
@@ -2,8 +2,17 @@
     "name": "theatre",
     "title": "Theatre Inserts",
     "description": "Theater Inserts with a visual novel style made for heavy roleplay scenes",
-    "version": "1.16.2",
-    "author": "Ken L, Noah Zorbaugh, U~man, KaKaRoTo, elizeuangelo",
+    "version": "1.20.0",
+    "authors": [
+        {
+            "name": "Ken L, Noah Zorbaugh, U~man, KaKaRoTo, elizeuangelo"
+        },
+        {
+            "name": "Geekswordsman",
+            "discord": "@Geekswordsman#3085"
+        }
+    ],
+    "author": "Ken L, Noah Zorbaugh, U~man, KaKaRoTo, elizeuangelo, Geekswordsman",
     "socket": true,
     "languages": [
         {
@@ -37,6 +46,11 @@
             "path": "app/lang/th.json"
         },
         {
+            "lang": "cn",
+            "name": "中文 (Chinese)",
+            "path": "app/lang/cn.json"
+        },
+        {
             "lang": "zh-tw",
             "name": "正體中文",
             "path": "app/lang/zh-tw.json"
@@ -65,17 +79,10 @@
     "styles": [
         "app/css/theatre.css"
     ],
-    "packs": [
-        {
-            "name": "theatre-inserts-macros",
-            "label": "Theatre Inserts Macros",
-            "path": "app/packs/theatre-inserts-macros.db",
-            "entity": "Macro"
-        }
-    ],
+    "packs": [],
     "url": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre",
-    "download": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/download/v1.16.2/theatre.zip",
+    "download": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/download/v1.17.0/theatre.zip",
     "manifest": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/download/latest/module.json",
     "minimumCoreVersion": "9",
-    "compatibleCoreVersion": "9.236"
+    "compatibleCoreVersion": "9"
 }


### PR DESCRIPTION
Creating v1.20.0, which makes Theatre Inserts compatible with v9 by fixing two issues (one error, one warning) that was preventing it from functioning within v9.

Added keybinding to new command - alt-s - which toggles all selected tokens with the stage.

Due to keybinding and changes, this new version is no longer compatible with Foundry v0.8.