### PR TITLE
Place game pause indicator on the bottom while no theatre is active & smoothly fade out bottom controls when creating a theatre

### DIFF
--- a/app/css/theatre.css
+++ b/app/css/theatre.css
@@ -1418,6 +1418,20 @@
 #players {
   z-index: 1; }
 
+#players, #hotbar {
+  transition: opacity 500ms ease 0ms;}
+
+/* id.class is utilized to gain priority over styling rules of the "Minimal UI" module */
+#players.theatre-invisible,
+#hotbar.theatre-invisible {
+  opacity: 0;
+  pointer-events: none;}
+
+#hotbar.theatre-invisible #hotbar-directory-controls,
+#hotbar.theatre-invisible #action-bar,
+#hotbar.theatre-invisible #hotbar-page-controls {
+  pointer-events: none;}
+
 @-moz-document url-prefix() {
   .emote-box .emotebar .colorselect {
     padding: 3px; }

--- a/app/css/theatre.css
+++ b/app/css/theatre.css
@@ -1410,7 +1410,10 @@
   pointer-events: none; } */
 
 #pause {
-  top: calc(50% - 50px); }
+  transition: bottom 500ms ease 0ms;}
+
+#pause.theatre-centered {
+  bottom: calc(50% - 50px); }
 
 #players {
   z-index: 1; }

--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -2223,8 +2223,10 @@ class Theatre {
 			insert.dockContainer = null; 
 			let idx = this.portraitDocks.findIndex(e => e.imgId == imgId);
 			this.portraitDocks.splice(idx,1); 
-			$('#players').show();
-			$('#hotbar').show();
+			// The "MyTab" module inserts another element with id "pause". Use querySelectorAll to make sure we catch both
+			document.querySelectorAll("#pause").forEach(ele => KHelpers.removeClass(ele, "theatre-centered"));
+			$('#players').removeClass("theatre-invisible");
+			$('#hotbar').removeClass("theatre-invisible");
 		}
 		// force a render update
 		//app.render(); 

--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -852,9 +852,13 @@ Hooks.once("init", () => {
  * Hide player list (and macro hotbar) when stage is active (and not suppressed)
  */
 Hooks.on("theatreDockActive", insertCount => {
-  if (!game.settings.get(Theatre.SETTINGS, "autoHideBottom")) return;
   if (!insertCount) return;
-  
+
+  // The "MyTab" module inserts another element with id "pause". Use querySelectorAll to make sure we catch both
+  document.querySelectorAll("#pause").forEach(ele => KHelpers.addClass(ele, "theatre-centered"));
+
+  if (!game.settings.get(Theatre.SETTINGS, "autoHideBottom")) return;
+
   $('#players').hide();
   if (!theatre.isSuppressed) $('#hotbar').hide();
 });
@@ -882,4 +886,10 @@ Hooks.on("theatreSuppression", suppressed => {
 
   if (suppressed) $(`#hotbar`).show();
   else $(`#hotbar`).hide();
+});
+
+Hooks.on("renderPause", () => {
+  if (!theatre?.dockActive) return;
+  // The "MyTab" module inserts another element with id "pause". Use querySelectorAll to make sure we catch both
+  document.querySelectorAll("#pause").forEach(ele => KHelpers.addClass(ele, "theatre-centered"));
 });

--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -859,8 +859,8 @@ Hooks.on("theatreDockActive", insertCount => {
 
   if (!game.settings.get(Theatre.SETTINGS, "autoHideBottom")) return;
 
-  $('#players').hide();
-  if (!theatre.isSuppressed) $('#hotbar').hide();
+  $('#players').addClass("theatre-invisible");
+  if (!theatre.isSuppressed) $('#hotbar').addClass("theatre-invisible");
 });
 
 /**
@@ -884,8 +884,8 @@ Hooks.on("theatreSuppression", suppressed => {
   if (!game.settings.get(Theatre.SETTINGS, "suppressMacroHotbar")) return;
   if (!theatre.dockActive) return;
 
-  if (suppressed) $(`#hotbar`).show();
-  else $(`#hotbar`).hide();
+  if (suppressed) $(`#hotbar`).removeClass("theatre-invisible");
+  else $(`#hotbar`).addClass("theatre-invisible");
 });
 
 Hooks.on("renderPause", () => {


### PR DESCRIPTION
This PR does two separate things. I've combined them into a single PR because they would cause merge conflicts if I created dedicated PRs. If you prefer having separate PRs I can still split them up, just let me know :)

## 1. Place game pause indicator on the bottom while no theatre is active
The first commit causes the Game Pause indicator to be placed at the bottom of the screen - where it is in vanilla foundry - while no theatre is active. If a theatre is being activated, the pause indicator will be smoothly animated to the center of the screen. Once the theatre is being closed, the pause indicator will be animated back to its original position.

## 2. Smoothly fade out the bottom controls
The second commit makes the bottom controls fade away with an animation instead of being abruptly removed.

As a nice effect this also fixes a bug where the scene controls would overlap the foundry icon while a theatre is active:
![grafik](https://user-images.githubusercontent.com/1705157/162154436-f41c9dd5-d9ee-42ac-ba84-3377bdabee77.png)

That bug would happen because `.hide()` completely removes an element from rendering. As a result, the width of the "players"-control will no longer push the scene control to the right (yes, foundry's layout works like that), which causes the scene control to jump to the left, where it overlaps the foundry icon.

Since the fading no longer uses `.hide()`, but instead reduces the opacity to 0, the elements become invisible, but don't lose their width. As a result the scene controls stay at the spot where they belong.