### PR TITLE
Add GM only setting (resolves #36)

### DIFF
--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -125,6 +125,8 @@ Handlebars.registerHelper("resprop", function(propPath, hash) {
  * Hook in on Actorsheet's Header buttons + context menus
  */
  Hooks.on("getActorSheetHeaderButtons",(app,buttons)=>{
+  if (!game.user.isGM && game.settings.get("theatre", "gmOnly")) return;
+
   let theatreButtons = []
   if (app.object.isOwner) {
     // only prototype actors
@@ -555,10 +557,8 @@ Hooks.on("createChatMessage", function(chatEntity, _, userId) {
   }
 });
 
-// Fixed global singleton/global object
-var theatre = null;
 Hooks.on("renderChatLog", function() {
-  theatre = new Theatre();
+  theatre.initialize();
   // window may not be ready?
   console.log(
     "%cTheatre Inserts",
@@ -575,6 +575,7 @@ Hooks.on("renderChatLog", function() {
  * Add to stage button on ActorDirectory Sidebar
  */
 Hooks.on("getActorDirectoryEntryContext", async (html, options) => {
+  if (!game.user.isGM && game.settings.get("theatre", "gmOnly")) return;
 
   const getActorData = target => {
     const actor = game.actors.get(target.data("documentId"));
@@ -594,8 +595,10 @@ Hooks.on("getActorDirectoryEntryContext", async (html, options) => {
   });
 });
 
-
+// Fixed global singleton/global object
+var theatre = null;
 Hooks.once("init", () => {
+  theatre = new Theatre();
   // module keybinds
 
   game.keybindings.register("theatre", "unfocusTextArea", {
@@ -883,3 +886,20 @@ Hooks.on("theatreSuppression", suppressed => {
   if (suppressed) $(`#hotbar`).show();
   else $(`#hotbar`).hide();
 });
+
+Hooks.on("getSceneControlButtons", controls => {
+  // Use "theatre", since Theatre.SETTINGS may not be available yet
+  if (!game.user.isGM && game.settings.get("theatre", "gmOnly")) {
+    const suppressTheatreTool = {
+      name: "suppressTheatre",
+      title: "Theatre.UI.Title.SuppressTheatre",
+      icon: "fas fa-theater-masks",
+      toggle: true,
+      active: false,
+      onClick: toggle => Theatre.instance.updateSuppression(toggle), // TODO Suppress theatre
+      visible: true,
+    };
+    const tokenControls = controls.find(group => group.name === "token").tools;
+    tokenControls.push(suppressTheatreTool);
+  }
+})

--- a/app/lang/de.json
+++ b/app/lang/de.json
@@ -51,6 +51,8 @@
 	"Theatre.UI.Settings.displayModeTextBox" : "Textbox-Stil",
 	"Theatre.UI.Settings.displayModeLightBox" : "Lichtkasten-Stil",
 	"Theatre.UI.Settings.displayModeClearBox" : "Transparenter Box-Stil",
+	"Theatre.UI.Settings.gmOnly" : "SSteuerung nur für Spielleiter",
+	"Theatre.UI.Settings.gmOnlyHint" : "Wenn diese Option aktiviert ist, kann nur der Spielleiter die Bühne steuern. Die Theatre-Steuerelemente werden für die Spieler ausgeblendet.",
 	"Theatre.UI.Settings.narrHeight" : "Erzähler-Leisten-Position",
 	"Theatre.UI.Settings.narrHeightHint" : "Die Position der Erzähler-Leiste als Prozentwert der Bildschirmhöhe.",
 	"Theatre.UI.Settings.textDecayMin" : "Minimum Textverfall-Zeit",

--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -51,6 +51,8 @@
 	"Theatre.UI.Settings.displayModeTextBox" : "Text Box Style",
 	"Theatre.UI.Settings.displayModeLightBox" : "Light Box Style",
 	"Theatre.UI.Settings.displayModeClearBox" : "Clear Box Style",
+	"Theatre.UI.Settings.gmOnly" : "GM controls only",
+	"Theatre.UI.Settings.gmOnlyHint" : "If enabled, only the GM will be able to control the stage. The Theatre controls will be hidden for the players.",
 	"Theatre.UI.Settings.narrHeight" : "Narrator Bar Position",
 	"Theatre.UI.Settings.narrHeightHint" : "The position of the narrator bar as a percentage of the screen height.",
 	"Theatre.UI.Settings.textDecayMin" : "Minimum Text Decay Time",


### PR DESCRIPTION
This PR adds a setting that allows the GM to hide the Theatre controls for the players, so they have exclusive control over the stage.

I opted to leave the controls in place on the player's clients and simply hide them. This is because there's other code besides the HTML injection part where the controls are being accessed. These other code locations would break if the controls weren't there, which would add complexity to the code to fix. With the way it's implemented all the code keeps working well because the controls are technically there and can be operated on, but they are still invisible to the players, achieving the desired result.

I've tested this change with both Minimal UI and MyTab enabled and disabled, and it works well in all cases.