### PR TITLE
Show the player list while the stage is suppressed if showing the macro hotbar is enabled

### DIFF
--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -859,8 +859,10 @@ Hooks.on("theatreDockActive", insertCount => {
 
   if (!game.settings.get(Theatre.SETTINGS, "autoHideBottom")) return;
 
-  $('#players').addClass("theatre-invisible");
-  if (!theatre.isSuppressed) $('#hotbar').addClass("theatre-invisible");
+  if (!theatre.isSuppressed) {
+    $('#players').addClass("theatre-invisible");
+    $('#hotbar').addClass("theatre-invisible");
+  }
 });
 
 /**
@@ -884,8 +886,14 @@ Hooks.on("theatreSuppression", suppressed => {
   if (!game.settings.get(Theatre.SETTINGS, "suppressMacroHotbar")) return;
   if (!theatre.dockActive) return;
 
-  if (suppressed) $(`#hotbar`).removeClass("theatre-invisible");
-  else $(`#hotbar`).addClass("theatre-invisible");
+  if (suppressed) {
+    $("#players").removeClass("theatre-invisible");
+    $("#hotbar").removeClass("theatre-invisible");
+  }
+  else {
+    $("#players").addClass("theatre-invisible");
+    $("#hotbar").addClass("theatre-invisible");
+  }
 });
 
 Hooks.on("renderPause", () => {

--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -63,7 +63,7 @@
 	"Theatre.UI.Settings.nameFontSizeHint": "Sets the size of the name font. Note that the sizes may be different depending on your display or font choice. Using huge sizes is not recommended.",
 	"Theatre.UI.Settings.autoHideBottom": "Auto Hide Bottom",
 	"Theatre.UI.Settings.autoHideBottomHint": "Hide bottom UI(player&hotbar) when actor shows on stage.",
-	"Theatre.UI.Settings.suppressMacroHotbar": "Show Macro Hotbar When Stage is Suppressed",
+	"Theatre.UI.Settings.suppressMacroHotbar": "Show Player List and Macro Hotbar When Stage is Suppressed",
 	"Theatre.UI.Settings.removeLabelSheetHeader": "Remove label from the header character sheet",
 	"Theatre.UI.Settings.removeLabelSheetHeaderHint": "Remove label from the header character sheet, Useful for little screen and mobile",
 

--- a/app/lang/es.json
+++ b/app/lang/es.json
@@ -64,7 +64,6 @@
 	"Theatre.UI.Settings.nameFontSizeHint": "Ajusta el tamaño de fuente de los nombres. Nótese que los tamaños pueden variar dependiendo del monitor o la fuente elegida. No se recomienza usar tamaños demasiado grandes",
 	"Theatre.UI.Settings.autoHideBottom": "Autoocultar UI inferior",
 	"Theatre.UI.Settings.autoHideBottomHint": "Oculta la UI inferior (jugador & barra de acceso rápido) cuando un actor sale a escena",
-	"Theatre.UI.Settings.suppressMacroHotbar": "Mostrar barra de macros cuando se quita el escenario",
 	"Theatre.UI.Settings.removeLabelSheetHeader": "Quitar etiquetas de las hojas de personaje",
 	"Theatre.UI.Settings.removeLabelSheetHeaderHint": "Quita la etiqueta del encabezado de las hojas de personaje, es útil cuando se usan monitores pequeños o dispositivos móviles",
 

--- a/app/lang/ja.json
+++ b/app/lang/ja.json
@@ -63,7 +63,6 @@
 	"Theatre.UI.Settings.nameFontSizeHint": "フォントの大きさを設定します。この設定は使用しているフォントや大きさによっては適切に機能しないかもしれません。大きすぎるフォントはお勧めしません。",
     "Theatre.UI.Settings.autoHideBottom": "PLリストとマクロを非表示",
 	"Theatre.UI.Settings.autoHideBottomHint": "立ち絵が出ているときに、画面の下部にあるPLリストとマクロバーを非表示にします。立ち絵の透明化を行うと再び出現します。",
-    "Theatre.UI.Settings.suppressMacroHotbar": "透明化時にマクロバーを表示",
 	"Theatre.UI.Settings.removeLabelSheetHeader": "控室に追加＋立ち絵設定の文字を消す",
 	"Theatre.UI.Settings.removeLabelSheetHeaderHint": "ウィンドウの上部に出る「控室に追加」や「立ち絵設定」の文字を消して文字数を少なくします。",
 

--- a/app/lang/ko.json
+++ b/app/lang/ko.json
@@ -63,7 +63,6 @@
 	"Theatre.UI.Settings.nameFontSizeHint": "액터 이름 글자의 크기를 조정합니다. ※주의 : 사용자의 디스플레이나 폰트 종류에 따라 사이즈가 달라질 수 있습니다. 너무 큰 크기는 권장하지 않습니다.",
 	"Theatre.UI.Settings.autoHideBottom": "하단 자동 감춤",
 	"Theatre.UI.Settings.autoHideBottomHint": "액터가 화면에 표시될 때 하단 UI (플레이어 목록, 단축바)를 감춥니다.",
-    	"Theatre.UI.Settings.suppressMacroHotbar": "무대 숨김 시 매크로 단축바 보이기",
 	"Theatre.UI.Settings.removeLabelSheetHeader": "캐릭터 시트 헤더에서 라벨 미표시",
 	"Theatre.UI.Settings.removeLabelSheetHeaderHint": "캐릭터 시트 헤더에서 라벨을 없앱니다. 작은 화면이나 모바일에서 유용합니다.",
 


### PR DESCRIPTION
Currently, Theatre can be configured to show the macro hotbar, while the stage is supressed. However, the player list remains hidden. This PR updates the code so that the player hotbar will be shown with the macro hotbar. Having access to the player list can have multiple uses: Pulling specific players to a scene or even kicking someone. Even just the ability to check which players are connected may be useful to some.

For this change I decided to re-use the "suppressMacroHotbar" setting and change it so it will show both, the macro hotbar and the player list. I did this to avoid cluttering the settings with too fine grained controls. Additionally, if players opted to show the macro hotbar during stage suppression, I don't see how showing the player list as well would hurt them. As a result putting both behaviors into a single setting seemed like the right choice. I decided to keep using the "suppressMacroHotbar" setting instead of renaming it to something more appropriate for the new behavior to ensure there would be no migration work required.

I've modified the English language file to reflect the change that I made. However, there are translations of that string available in other languages, which I cannot update, that would need to be adjusted by someone else. Should I delete the relevant string from the other language files to indicate to the translators that that string needs retranslation?