### PR TITLE
Wait with construction of Theatre object until translation strings are ready (fixes #96)

### DIFF
--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -597,8 +597,11 @@ Hooks.on("getActorDirectoryEntryContext", async (html, options) => {
 
 // Fixed global singleton/global object
 var theatre = null;
-Hooks.once("init", () => {
+Hooks.once("setup", () => {
   theatre = new Theatre();
+});
+
+Hooks.once("init", () => {
   // module keybinds
 
   game.keybindings.register("theatre", "unfocusTextArea", {


### PR DESCRIPTION
3cba9929 moved the construction of the Theatre object to the `init` hook to register some game settings in time. However, construction of the Theatre object requires translation strings to be available. However, the localization system isn't available yet during the `init` hook, so the translation will fail - which in turn will lead to bug #96.

This PR moves the construction of the Theatre object to the `setup` hook, where translations are already available, while keeping it early enough that the settings should still be registered early enough.