### PR TITLE
Fix bug that <br> tag is displayed when line breaks are made

### DIFF
--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -396,6 +396,7 @@ Hooks.on("createChatMessage", function(chatEntity, _, userId) {
   textContent = textContent.replace(/&gt;/g, ">");
   textContent = textContent.replace(/&lt;/g, "<");
   textContent = textContent.replace(/&amp;/g, "&");
+  textContent = textContent.replace(/<br>/g, "\n");
 
   if (textBox) {
     // kill all tweens


### PR DESCRIPTION
### Why
When a line break is made by pressing Shift+Enter in a chat box, a `<br>` tag appears in the display of the module's text.

### What
In the following, newline characters are processed, but this bug occurs because the actual processing passes the string of the notation by `<br>` tag, not the newline character.

https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/blob/66cfcfcc52fa6e4df88f15311328a597ade986dc/app/js/Theatre.js#L7750-L7779

You can fix this bug by replacing `<br>` tags in the text with newline characters in advance.
<br>
**Thank you for your consideration.**