### PR TITLE
Fixed popout issue + gramatical error on the settings gmOnly

### DIFF
--- a/app/js/Theatre.js
+++ b/app/js/Theatre.js
@@ -331,7 +331,7 @@ class Theatre {
 			hint: "Theatre.UI.Settings.gmOnlyHint",
 			scope: "world",
 			config: true,
-			defualt: false,
+			default: false,
 			type: Boolean,
 			onChange: () => {if (!game.user.isGM) location.reload();},
 		});
@@ -387,7 +387,7 @@ class Theatre {
 			config: true,
 			default: Theatre.instance.titleFont,
 			type: String,
-		choices: Theatre.FONTS.reduce((a, font) => { a[font]=font;
+		    choices: Theatre.FONTS.reduce((a, font) => { a[font]=font;
 			return a;
 		}, {}),
 		});

--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -558,7 +558,8 @@ Hooks.on("createChatMessage", function(chatEntity, _, userId) {
   }
 });
 
-Hooks.on("renderChatLog", function() {
+Hooks.on("renderChatLog", function(app, html, data) {
+  if (data.cssId === "chat-popout") return;
   theatre.initialize();
   // window may not be ready?
   console.log(


### PR DESCRIPTION
The gmOnly setting had a gramatical error since its introduction when pushed on 3cba992925e5766b71365f1943970f3007c664fe
The popout error was fixed by identifying when the chat is rendering on popout and when it isnt.