### PR TITLE
add polyglot support

### DIFF
--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -432,7 +432,6 @@ Hooks.on("createChatMessage", function (chatEntity, _, userId) {
 			insertFontSize = Number(Theatre.instance.theatreNarrator.getAttribute("textsize"));
 			insertFontColor = Theatre.instance.theatreNarrator.getAttribute("textcolor");
 		}
-
 		let fontSize = Number(textBox.getAttribute("osize") || 28);
 		//console.log("font PRE(%s): ",insertFontSize,fontSize)
 		switch (insertFontSize) {
@@ -451,6 +450,34 @@ Hooks.on("createChatMessage", function (chatEntity, _, userId) {
 		textBox.style.color = insertFontColor || "white";
 		textBox.style["font-size"] = `${fontSize}px`;
 		textBox.scrollTop = 0;
+		if (typeof polyglot !== 'undefined') {
+			// Get current language being processed
+			const lang = chatData.flags.polyglot.language;
+			// Fetch the languages known by current user
+			let langs = game.polyglot.getUserLanguages();
+			let understood = false;
+			for (lang_set of langs.values()) {
+			  for (item of lang_set.values()) {
+				// If the user has a matching language in their list, we understand it
+				if (lang == item) {
+				  understood = true;
+				  break;
+				}
+			  }
+			}			
+		if (game.user.isGM || game.user.name == "Stream" || game.user.name == "stream"){
+			understood = true;
+		}
+		if (!understood) {
+			// If not understood, scramble the text
+			const fontStyle = game.polyglot._getFontStyle(lang);
+			fontSize *= Math.floor(Number(fontStyle.slice(0,3))/100);
+			insertFontType = fontStyle.slice(5);
+			textContent = game.polyglot.scrambleString(textContent, chatData._id, lang);
+			}
+		}
+
+
 
 		charSpans = Theatre.splitTextBoxToChars(textContent, textBox);
 


### PR DESCRIPTION
Reintroduces and updates polyglot integration to use polyglot's new members. A better way to do this would be probably to use isLanguageUnderstood() or something, but I'm a JS newbie.

This, at least:

-Scrambles the text contents of theatre insert text boxes for players who don't understand the Polyglot language used
-Will not scramble for GMs, or users named "Stream" or "stream" (for the default use case of the popular Stream View module). Probably overkill to add an option for this; people who really want scrambled messages for all can just edit out the name check.

I don't think this will correctly take into account omniglot or comprehend languages, but it should be enough of a basic patch to make most users of both modules happy. I'll have more of a look later.

I've tested it on my machine but this is one of my first commits to a public repo so please double check if you have time.

Thanks again for updating theatre to v11; I have a game in a few hours, so I was very pleased to see it back.