### PR TITLE
Fix polyglot support breaking emotes

### DIFF
--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -451,7 +451,8 @@ Hooks.on("createChatMessage", function (chatEntity, _, userId) {
 		textBox.style.color = insertFontColor || "white";
 		textBox.style["font-size"] = `${fontSize}px`;
 		textBox.scrollTop = 0;
-		if (typeof polyglot !== 'undefined') {
+		// If polyglot is active, and message contains its flag (e.g. not an emote), begin processing
+		if (typeof polyglot !== 'undefined' && typeof chatData.flags.polyglot !== 'undefined') {
 			// Get current language being processed
 			const lang = chatData.flags.polyglot.language;
 			// Fetch the languages known by current user

--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -219,7 +219,7 @@ Hooks.on("deleteCombat", function () {
  * Pre-process chat message to set 'speaking as' to correspond
  * to our 'speaking as'
  */
-Hooks.on("preCreateChatMessage", function (chatMessage) {
+/*Hooks.on("preCreateChatMessage", function (chatMessage) {
 	let chatData = {
 		speaker: {
 			//actor: null, 
@@ -302,7 +302,7 @@ Hooks.on("preCreateChatMessage", function (chatMessage) {
 			game.i18n.localize(`Theatre.Text.CloseBracket.${Theatre.instance.settings.quoteType}`);
 	}
 	chatMessage.updateSource(chatData);
-});
+});*/
 
 /**
  * Chat message Binding


### PR DESCRIPTION
With the introduction of Polyglot support, emotes were broken, because Polyglot never assigns those messages a flag. Emotes are never supposed to be in another language, after all.

This small fix checks if the message has the polyglot flag. If it doesn't, we shouldn't bother with processing languages and scrambling.