### PR TITLE
Fix Polyglot support breaking emotes

### DIFF
--- a/app/js/theatre_main.js
+++ b/app/js/theatre_main.js
@@ -451,7 +451,8 @@ Hooks.on("createChatMessage", function (chatEntity, _, userId) {
 		textBox.style.color = insertFontColor || "white";
 		textBox.style["font-size"] = `${fontSize}px`;
 		textBox.scrollTop = 0;
-		if (typeof polyglot !== 'undefined') {
+		// If polyglot is active, and message contains its flag (e.g. not an emote), begin processing
+		if (typeof polyglot !== 'undefined' && typeof chatData.flags.polyglot !== 'undefined') {
 			// Get current language being processed
 			const lang = chatData.flags.polyglot.language;
 			// Fetch the languages known by current user


### PR DESCRIPTION
(Let's try this again, after I woke up realizing I merged the master branch instead of the commit.)

With the introduction of Polyglot support, emotes were broken, because Polyglot never assigns those messages a flag. Emotes are never supposed to be in another language, after all.

This small fix checks if the message has the polyglot flag. If it doesn't, we shouldn't bother with processing languages and scrambling.