### PR TITLE
Support higher pixel densities via core pixel ratio scaling setting

### DIFF
--- a/src/scripts/Theatre.js
+++ b/src/scripts/Theatre.js
@@ -2107,6 +2107,7 @@ export class Theatre {
       backgroundAlpha: 0,
       antialias: true,
       width: document.body.offsetWidth,
+      resolution: game.settings.get("core", "pixelRatioResolutionScaling") ? window.devicePixelRatio : 1
     });
 
     let canvas = app.view;


### PR DESCRIPTION
This is a single-line PR that adds support for higher pixel densities (for retina displays, etc.) if the user has enabled the core Foundry setting "Pixel Ratio Resolution Scaling." It allows Theatre Inserts images to match the pixel density of the rest of the Foundry canvas, which avoids situations where on retina displays theatre images can be noticeably blurry compared to canvas graphics when using high-resolution actor images.