### PR TITLE
Adds the Speaker's Scene to the Chat Message

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -137,12 +137,12 @@ Hooks.on("deleteCombat", function () {
  * Pre-process chat message to set 'speaking as' to correspond
  * to our 'speaking as'
  */
-Hooks.on("preCreateChatMessage", function (chatMessage) {
+Hooks.on("preCreateChatMessage", function (chatMessage, data) {
   let chatData = {
     speaker: {
       //actor: null,
       //The above line is causing issues with chat buttons in v11 in certain systems. Will revert if it causes unforseen issues in other systems.
-      scene: null,
+      scene: data.speaker?.scene,
       flags: {},
     },
   };


### PR DESCRIPTION
Some other modules like Automated Animations actually use the speaker scene data and they become incompatible with Theatre Inserts because of the ChatData override, wich removes lot of the message information.

I have not refactored the entire preCreateMessage because i'm not that familiar to take that risk but I have not seen any other functions in the module using the speaker scene data.