### PR TITLE
Added option for image height as a percentage of the device screen height and option for uniform images size

### DIFF
--- a/src/scripts/Theatre.js
+++ b/src/scripts/Theatre.js
@@ -2300,8 +2300,15 @@ export class Theatre {
         let sprite = new PIXI.Sprite(resources[resName]);
         let portWidth = resources[resName].width;
         let portHeight = resources[resName].height;
-        let maxHeight = game.settings.get(CONSTANTS.MODULE_ID, "theatreImageSize");
-        if (portHeight > maxHeight) {
+
+        let usePercent = game.settings.get(CONSTANTS.MODULE_ID, "theatreImageUsePercent");
+        let maxHeightPixel = game.settings.get(CONSTANTS.MODULE_ID, "theatreImageSize");
+        let maxHeightPercent = window.innerHeight * game.settings.get(CONSTANTS.MODULE_ID, "theatreImageSizePercent");
+        let useUniform = game.settings.get(CONSTANTS.MODULE_ID, "theatreImageSizeUniform");
+
+        let maxHeight = usePercent ? maxHeightPercent : maxHeightPixel;
+
+        if (portHeight > maxHeight || useUniform) {
             portWidth *= maxHeight / portHeight;
             portHeight = maxHeight;
         }

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -63,7 +63,7 @@ export const registerSettings = function () {
 
     game.settings.register(CONSTANTS.MODULE_ID, "theatreImageSizePercent", {
         name: "Maximum image height (percent)",
-        hint: "Uniform image height as a percentage of the device screen height",
+        hint: "Set max image height as a percentage of the device screen height. Used only if the 'Use screen height as maximum image height' is enabled",
         scope: "client",
         config: true,
         default: 0.7,

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -52,6 +52,33 @@ export const registerSettings = function () {
         type: Number,
     });
 
+    
+    game.settings.register(CONSTANTS.MODULE_ID, "theatreImageUsePercent", {
+        name: "Use screen height as maximum image height",
+        scope: "world",
+        config: true,
+        default: false,
+        type: Boolean,
+    });
+
+    game.settings.register(CONSTANTS.MODULE_ID, "theatreImageSizePercent", {
+        name: "Maximum image height (percent)",
+        hint: "Uniform image height as a percentage of the device screen height",
+        scope: "client",
+        config: true,
+        default: 0.7,
+        type: Number
+      });
+
+    game.settings.register(CONSTANTS.MODULE_ID, "theatreImageSizeUniform", {
+        name: "Uniform image height",
+        hint: "Set all images size to the maximum height",
+        scope: "world",
+        config: true,
+        default: false,
+        type: Boolean,
+    });
+
     game.settings.register(CONSTANTS.MODULE_ID, "theatreNarratorHeight", {
         name: "Theatre.UI.Settings.narrHeight",
         hint: "Theatre.UI.Settings.narrHeightHint",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fb85044a-8510-4385-9860-0fb3c27b84e8)

All the options is disabled by default