### PR TITLE
chore: publish new releases to foundry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Release Creation
 
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   build:
@@ -67,12 +67,12 @@ jobs:
       #- run: zip -r ./module.zip module.json LICENSE module.js module.js.map style.css templates/ languages/ packs/ assets/
       # - run: zip -r ./package/module.zip ./package/*
 
-      # && ensures that zip only runs if the directory was correctly changed, 
-      # and the parentheses run everything in a subshell, so the current directory 
+      # && ensures that zip only runs if the directory was correctly changed,
+      # and the parentheses run everything in a subshell, so the current directory
       # is restored at the end. Using OLDPWD avoids having to calculate the relative path to package.zip.
       # https://unix.stackexchange.com/questions/385405/zip-all-files-and-subfolder-in-directory-without-parent-directory
       - run: (cd package && zip -r "$OLDPWD/module.zip" .)
-      
+
       - name: Update Release with Files
         id: create_version_release
         uses: ncipollo/release-action@v1
@@ -131,3 +131,13 @@ jobs:
       #     git checkout stash module.json
       #     git commit -m "${{github.event.release.tag_name}} manifest"
       #     git push -f
+
+      # Publish this new version to the Foundry VTT Module Listing
+      - name: Publish to Foundry VTT Repo
+        id: publish_foundry_repo
+        run: npx @ghost-fvtt/foundry-publish
+        env:
+          FVTT_DRY_RUN: ${{ github.event.release.prerelease }}
+          FVTT_MANIFEST_PATH: src/module.json
+          FVTT_TOKEN: ${{ secrets.FVTT_TOKEN }}
+          FVTT_MANIFEST_URL: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/module.json


### PR DESCRIPTION
a new secret called `FVTT_TOKEN` needs to be added to the repository actions: https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/settings/secrets/actions
it needs to contain the value of the field `Package Release Token` that you can get from here: https://foundryvtt.com/packages/theatre/edit