### PR TITLE
feat: new setting to show more than 5 actors on top of screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+### 3.1.1
+- Add setting to move stage to the top when there are more than 5 actors
+
 ### 3.1.0
 - Show emote on tooltip
+- Support gif files
 
 ### 3.0.1
 - Add compatibility for Foundry VTT 13.347

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "theatre",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "theatre",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "theatre",
     "title": "Theatre Inserts",
     "description": "Theater Inserts with a visual novel style made for heavy roleplay scenes",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "main": "module.js",
     "license": "SEE LICENSE IN LICENSE",
     "private": true,

--- a/src/lang/cn.json
+++ b/src/lang/cn.json
@@ -83,7 +83,9 @@
           "2": "【方头括号】",
           "3": "｢鍵括号｣",
           "4": "『双重键括号』"
-        }
+        },
+        "showActorsOnTop": "在屏幕顶部显示角色",
+        "showActorsOnTopHint": "如果启用，当有超过5个角色时，角色将显示在屏幕顶部。"
       },
       "Keybinds": {
         "unfocusTextArea": "取消聚焦文本框",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -59,6 +59,8 @@
   "Theatre.UI.Settings.textDecayMinHint": "Das Minimum an Zeit in Sekunden befor der Theater Text Eintrag beginnt zu verschwinden.",
   "Theatre.UI.Settings.textDecayRate": "Textverfallrate",
   "Theatre.UI.Settings.textDecayRateHint": "Die Rate in der der Text verschwindet, basierend auf der Länge der Nachricht in Sekunden. Dies wird *pro Zeichen* angewendet, so dass 100 Zeichen 100 Sekunden entsprechen, bevor der Text verschwindet, wenn die Rate auf 1s gestellt wird, ODER die Minimum Textverfall-Zeit, welches höher ist.",
+  "Theatre.UI.Settings.showActorsOnTop": "Aktoren oben anzeigen",
+  "Theatre.UI.Settings.showActorsOnTopHint": "Wenn aktiviert, werden Akteure oben auf dem Bildschirm angezeigt, wenn mehr als 5 Akteure vorhanden sind.",
 
   "Theatre.MOTD.Header": "Theater Benachrichtigung",
   "Theatre.MOTD.OldVersion": "Theater ist aktuell veraltet, bitte lass es von deinem SL in den Einstellungen aktualisieren.",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -92,6 +92,8 @@
           "3": "｢Kagikakko｣",
           "4": "『Nijū Kagiyamakakko』"
         },
+        "showActorsOnTop": "Show actors on top of the screen",
+        "showActorsOnTopHint": "If enabled, actors will be displayed on top of the screen when there are more than 5 actors.",
         "debug": "Enable debugging",
         "debugHint": "Prints debug messages to the console"
       },

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -69,6 +69,8 @@
   "Theatre.UI.Settings.suppressMacroHotbar": "Mostrar lista de jugadores y barra de macros cuando se sale del modo escenario",
   "Theatre.UI.Settings.removeLabelSheetHeader": "Quitar etiquetas de las hojas de personaje",
   "Theatre.UI.Settings.removeLabelSheetHeaderHint": "Quita la etiqueta del encabezado de las hojas de personaje, es útil cuando se usan monitores pequeños o dispositivos móviles",
+  "Theatre.UI.Settings.showActorsOnTop": "Mostrar actores en la parte superior de la pantalla",
+  "Theatre.UI.Settings.showActorsOnTopHint": "Si se habilita, los actores se mostrarán en la parte superior de la pantalla cuando haya más de 5 actores.",
 
   "Theatre.UI.Keybinds.unfocusTextArea": "Quitar foco del área de texto",
   "Theatre.UI.Keybinds.addOwnedToStage": "Añadir tus actores al escenario",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -53,6 +53,8 @@
   "Theatre.UI.Settings.textDecayMinHint": "Le temps minimum en secondes avant que le texte affiché dans théâtre ne commence a disparaître.",
   "Theatre.UI.Settings.textDecayRate": "Vitesse de disparition du texte",
   "Theatre.UI.Settings.textDecayRateHint": "La vitesse à laquelle le texte disparaît, en fonction de la durée du message en secondes. Ceci dépend du nombre de caractères, donc un texte de 100 caractères met 100s avant de disparaitre si la vitesse de disparition est de 1s.",
+  "Theatre.UI.Settings.showActorsOnTop": "Afficher les acteurs en haut de l'écran",
+  "Theatre.UI.Settings.showActorsOnTopHint": "Si activé, les acteurs seront affichés en haut de l'écran lorsqu'il y a plus de 5 acteurs.",
 
   "Theatre.MOTD.Header": "Notification de Théâtre",
   "Theatre.MOTD.OldVersion": "Théâtre n'est plus a jour, s'il vous plait demandez au GM de mètre a jour Théâtre.",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -65,6 +65,8 @@
   "Theatre.UI.Settings.autoHideBottomHint": "立ち絵が出ているときに、画面の下部にあるPLリストとマクロバーを非表示にします。立ち絵の透明化を行うと再び出現します。",
   "Theatre.UI.Settings.removeLabelSheetHeader": "控室に追加＋立ち絵設定の文字を消す",
   "Theatre.UI.Settings.removeLabelSheetHeaderHint": "ウィンドウの上部に出る「控室に追加」や「立ち絵設定」の文字を消して文字数を少なくします。",
+  "Theatre.UI.Settings.showActorsOnTop": "画面の上部にキャラクターを表示",
+  "Theatre.UI.Settings.showActorsOnTopHint": "有効にすると、5人以上のキャラクターがいるときに画面の上部に表示されます。",
 
   "Theatre.UI.Keybinds.unfocusTextArea": "チャットから注目を外す",
   "Theatre.UI.Keybinds.addOwnedToStage": "所有しているすべてのコマを控室に追加",

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -68,6 +68,8 @@
   "Theatre.UI.Settings.suppressMacroHotbar": "무대가 사라졌을 때 플레이어 목록과 매크로 단축바 표시하기",
   "Theatre.UI.Settings.removeLabelSheetHeader": "캐릭터 시트 헤더 라벨 미표시",
   "Theatre.UI.Settings.removeLabelSheetHeaderHint": "캐릭터 시트 헤더 라벨을 없앱니다. 작은 화면이나 모바일에서 유용합니다.",
+  "Theatre.UI.Settings.showActorsOnTop": "화면 상단에 배우 표시",
+  "Theatre.UI.Settings.showActorsOnTopHint": "활성화하면 5명 이상의 배우가 있을 때 화면 상단에 표시됩니다.",
 
   "Theatre.UI.Keybinds.unfocusTextArea": "채팅칸 포커스 해제",
   "Theatre.UI.Keybinds.addOwnedToStage": "소유한 액터 무대에 추가",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -53,6 +53,8 @@
   "Theatre.UI.Settings.textDecayMinHint": "A quantidade mínima de tempo em segundos antes do texto começar a decair.",
   "Theatre.UI.Settings.textDecayRate": "Taxa de Decaída do Texto",
   "Theatre.UI.Settings.textDecayRateHint": "A taxa em que o texto vai decair, baseada no comprimento da mensagem, em segundos. Isso é aplicado *por caractere*, portanto, uma mensagem com 100 caracteres tem 100s antes de decair completamente se a taxa for 1s, OU o tempo mínimo para o texto decair, o que for maior.",
+  "Theatre.UI.Settings.showActorsOnTop": "Mostrar atores na parte superior da tela",
+  "Theatre.UI.Settings.showActorsOnTopHint": "Se ativado, os atores serão exibidos na parte superior da tela quando houver mais de 5 atores.",
 
   "Theatre.MOTD.Header": "Notificação do Theatre",
   "Theatre.MOTD.OldVersion": "O Theatre está desatualizado. Por favor, peça para seu GM atualizar o Theatre na tela de configurações.",

--- a/src/lang/th.json
+++ b/src/lang/th.json
@@ -53,6 +53,8 @@
   "Theatre.UI.Settings.textDecayMinHint": "เวลาขั้นต่ำเป็นวินาที ก่อนที่ตัวอักษรใน theatre จะหายไป",
   "Theatre.UI.Settings.textDecayRate": "อัตราการจางของตัวอักษร",
   "Theatre.UI.Settings.textDecayRateHint": "ความเร็วในการหายไปของตัวอักษร ขึ้นอยู่กับความยาวของข้อความในหน่วยวินาทีต่อตัวอักษร เช่นข้อความที่มีอักษร 100 ตัว จะแสดง 100 วิก่อนที่จะหายไป ถ้าอัตราการหายไปของตัวอักษรคือ 1 วิ หรือเมื่อถึงเวลาขั้นต่ำที่จะให้ตัวอักษรหายไป นับตามค่าสูงสุด",
+  "Theatre.UI.Settings.showActorsOnTop": "แสดงนักแสดงที่ด้านบนของหน้าจอ",
+  "Theatre.UI.Settings.showActorsOnTopHint": "หากเปิดใช้งาน นักแสดงจะถูกแสดงที่ด้านบนของหน้าจอเมื่อมีนักแสดงมากกว่า 5 คน",
 
   "Theatre.MOTD.Header": "แจ้งเตือน Theatre",
   "Theatre.MOTD.OldVersion": "Theatre ขณะนี้ล้าสมัย, กรุณาบอก GM ให้อัปเดต theatre ในหน้าตั้งค่า",

--- a/src/lang/zh-tw.json
+++ b/src/lang/zh-tw.json
@@ -57,6 +57,8 @@
   "Theatre.UI.Settings.textDecayMinHint": "劇院文本輸入衰减之前的最短時間（以秒爲單位）。",
   "Theatre.UI.Settings.textDecayRate": "文字延遲率",
   "Theatre.UI.Settings.textDecayRateHint": "基于消息的長度（以秒爲單位），文本衰减的速率。 這是“按每個字符”應用的，因此，如果衰减率爲1s或最小衰减時間（以較大者爲准），則在衰减之前100s的消息是100s。",
+  "Theatre.UI.Settings.showActorsOnTop": "顯示演員在屏幕上方",
+  "Theatre.UI.Settings.showActorsOnTopHint": "如果啟用，當有超過5個演員時，演員將顯示在屏幕上方。",
 
   "Theatre.MOTD.Header": "通知",
   "Theatre.MOTD.OldVersion": "劇院當前已過時，請在設置屏幕中啓用GM更新劇場。",

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
     "id": "theatre",
     "title": "Theatre Inserts",
     "description": "Theater Inserts with a visual novel style made for heavy roleplay scenes",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "authors": [
         {
             "name": "Ken L"
@@ -150,7 +150,7 @@
     "manifestPlusVersion": "1.2.1",
     "url": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre",
     "manifest": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/latest/download/module.json",
-    "download": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/download/3.1.0/module.zip",
+    "download": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/download/3.1.1/module.zip",
     "readme": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/blob/master/README.md",
     "changelog": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/blob/master/CHANGELOG.md",
     "bugs": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/issues",

--- a/src/scripts/constants/constants.js
+++ b/src/scripts/constants/constants.js
@@ -1,21 +1,22 @@
 const CONSTANTS = {
-  MODULE_ID: "theatre",
-  PATH: `modules/theatre/`,
-  PREFIX_I18N: `Theatre`,
-  FLAGS: {},
-  API: {
-    EVENT_TYPE: {
-      sceneevent: "sceneevent",
-      typingevent: "typingevent",
-      resyncevent: "resyncevent",
-      reqresync: "reqresync",
+    MODULE_ID: "theatre",
+    PATH: `modules/theatre/`,
+    PREFIX_I18N: `Theatre`,
+    FLAGS: {},
+    API: {
+        EVENT_TYPE: {
+            sceneevent: "sceneevent",
+            typingevent: "typingevent",
+            resyncevent: "resyncevent",
+            reqresync: "reqresync",
+        },
     },
-  },
-  SOCKET: "module.theatre",
-  NARRATOR: "Narrator",
-  ICONLIB: "modules/theatre/assets/graphics/emotes",
-  DEFAULT_PORTRAIT: "icons/mystery-man.png",
-  PREFIX_ACTOR_ID: "theatre-",
+    SOCKET: "module.theatre",
+    NARRATOR: "Narrator",
+    ICONLIB: "modules/theatre/assets/graphics/emotes",
+    DEFAULT_PORTRAIT: "icons/mystery-man.png",
+    PREFIX_ACTOR_ID: "theatre-",
+    MAX_NUM_ACTORS_ON_CONTROL_GROUP: 5,
 };
 
 CONSTANTS.PATH = `modules/${CONSTANTS.MODULE_ID}/`;

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -1,4 +1,5 @@
 import { Theatre } from "./Theatre.js";
+import { TheatreHelpers } from "./theatre-helpers.js";
 import CONSTANTS from "./constants/constants.js";
 import Logger from "./lib/Logger.js";
 
@@ -52,7 +53,6 @@ export const registerSettings = function () {
         type: Number,
     });
 
-    
     game.settings.register(CONSTANTS.MODULE_ID, "theatreImageUsePercent", {
         name: "Use screen height as maximum image height",
         scope: "world",
@@ -67,8 +67,8 @@ export const registerSettings = function () {
         scope: "client",
         config: true,
         default: 0.7,
-        type: Number
-      });
+        type: Number,
+    });
 
     game.settings.register(CONSTANTS.MODULE_ID, "theatreImageSizeUniform", {
         name: "Uniform image height",
@@ -210,7 +210,7 @@ export const registerSettings = function () {
         scope: "world",
         config: true,
         default: "",
-        type: String
+        type: String,
     });
 
     game.settings.register(CONSTANTS.MODULE_ID, "showUIAboveStage", {
@@ -268,6 +268,18 @@ export const registerSettings = function () {
         },
         onChange: (value) => {
             settingsCustom.quoteType = value;
+        },
+    });
+
+    game.settings.register(CONSTANTS.MODULE_ID, "showActorsOnTop", {
+        name: "Theatre.UI.Settings.showActorsOnTop",
+        hint: "Theatre.UI.Settings.showActorsOnTopHint",
+        scope: "client",
+        config: true,
+        type: Boolean,
+        default: false,
+        onChange: () => {
+            TheatreHelpers.relocateStage(true);
         },
     });
 

--- a/src/scripts/theatre-helpers.js
+++ b/src/scripts/theatre-helpers.js
@@ -2311,6 +2311,7 @@ export class TheatreHelpers {
         Theatre.instance.stageInsertById(theatreId);
         // Store reference
         Theatre.instance.stage[theatreId] = new TheatreActor(actor, navItem);
+        TheatreHelpers.relocateStage();
     }
 
     /**
@@ -2324,6 +2325,7 @@ export class TheatreHelpers {
         }
         const theatreId = Theatre._getTheatreId(actor);
         Theatre.instance._removeFromStage(theatreId);
+        TheatreHelpers.relocateStage();
     }
 
     /**
@@ -2339,6 +2341,7 @@ export class TheatreHelpers {
             }
             Theatre.instance.removeInsertById(theatreId);
             delete Theatre.instance.stage[theatreId];
+            TheatreHelpers.relocateStage();
         }
     }
 
@@ -2357,6 +2360,40 @@ export class TheatreHelpers {
         Object.keys(Theatre.instance.stage).forEach((theatreId) => {
             Theatre.instance._removeFromStage(theatreId);
         });
+        TheatreHelpers.relocateStage();
+    }
+
+    static relocateStage(forceUpdate = false) {
+        const showActorsOnTop = game.settings.get(CONSTANTS.MODULE_ID, "showActorsOnTop");
+        if (!showActorsOnTop && !forceUpdate) {
+            return;
+        }
+        const keys = Object.keys(Theatre.instance.stage);
+        if (keys.length <= CONSTANTS.MAX_NUM_ACTORS_ON_CONTROL_GROUP || !showActorsOnTop) {
+            // move nav bar to chat box
+            const controlGroup = document.getElementsByClassName("theatre-control-group")[0];
+            if (!controlGroup) {
+                return;
+            }
+            const navBar = controlGroup.getElementsByClassName("theatre-control-nav-bar")[0];
+            if (navBar) {
+                return;
+            }
+            KHelpers.insertBefore(Theatre.instance.theatreNavBar, controlGroup.firstChild);
+            Logger.debug("moved nav bar to chat box");
+            return;
+        }
+        // move nav bar to top of screen
+        const uiTop = document.getElementById("ui-top");
+        if (!uiTop) {
+            return;
+        }
+        const navBar = uiTop.getElementsByClassName("theatre-control-nav-bar")[0];
+        if (navBar) {
+            return;
+        }
+        uiTop.appendChild(Theatre.instance.theatreNavBar);
+        Logger.debug("moved nav bar to top of screen");
     }
 
     /**

--- a/src/styles/theatre.css
+++ b/src/styles/theatre.css
@@ -1220,6 +1220,7 @@
   border-radius: 5px;
   border: 1px solid #212121;
   overflow-y: hidden;
+  max-height: 40px;
 }
 
 .theatre-control-nav-bar-item {


### PR DESCRIPTION
It will work the same with less than 6 actors:
<img width="399" height="237" alt="image" src="https://github.com/user-attachments/assets/84b76d95-31f4-45ae-8e91-2982f4be8d92" />

it will move to the top with more than 5 actors:
<img width="1843" height="119" alt="image" src="https://github.com/user-attachments/assets/1394619f-2769-4ad2-b1bf-0f63a6e45b82" />

It can be tested using this url to install the module:
`https://github.com/samulopez/fvtt-module-theatre/releases/latest/download/module.json`