### PR TITLE
refactor: migrate to ApplicationV2 and remove all the deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-### 3.1.1
+### 3.3.0
+- Migrate to ApplicationV2 and remove all the deprecation warnings
+
+### 3.2.0
 - Add setting to move stage to the top when there are more than 5 actors
 
 ### 3.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "theatre",
-    "version": "3.1.1",
+    "version": "3.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "theatre",
-            "version": "3.1.1",
+            "version": "3.3.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "theatre",
     "title": "Theatre Inserts",
     "description": "Theater Inserts with a visual novel style made for heavy roleplay scenes",
-    "version": "3.1.1",
+    "version": "3.3.0",
     "main": "module.js",
     "license": "SEE LICENSE IN LICENSE",
     "private": true,

--- a/src/module.js
+++ b/src/module.js
@@ -187,8 +187,6 @@ Hooks.on("deleteCombat", function () {
 Hooks.on("preCreateChatMessage", function (chatMessage, data) {
     let chatData = {
         speaker: {
-            // Actor: null,
-            // The above line is causing issues with chat buttons in v11 in certain systems. Will revert if it causes unforseen issues in other systems.
             scene: data.speaker?.scene,
             flags: {},
         },
@@ -204,7 +202,7 @@ Hooks.on("preCreateChatMessage", function (chatMessage, data) {
 
     // Make the message OOC if needed
     if ($(theatre.theatreChatCover).hasClass("theatre-control-chat-cover-ooc")) {
-        const user = game.users.get(chatMessage.user.id);
+        const user = game.users.get(chatMessage.author.id);
         chatData.speaker.alias = user.name;
         if (foundry.utils.isNewerVersion(game.version, 12)) {
             chatData.style = CONST.CHAT_MESSAGE_STYLES.OOC;
@@ -216,20 +214,16 @@ Hooks.on("preCreateChatMessage", function (chatMessage, data) {
         return;
     }
 
-    if (Theatre.instance.speakingAs && Theatre.instance.usersTyping[chatMessage.user.id]) {
-        let theatreId = Theatre.instance.usersTyping[chatMessage.user.id].theatreId;
+    if (Theatre.instance.speakingAs && Theatre.instance.usersTyping[chatMessage.author.id]) {
+        let theatreId = Theatre.instance.usersTyping[chatMessage.author.id].theatreId;
         let insert = Theatre.instance.getInsertById(theatreId);
-        let actorId = theatreId.replace(CONSTANTS.PREFIX_ACTOR_ID, "");
-        let actor = game.actors.get(actorId) || null;
         Logger.debug("speakingAs %s", theatreId);
 
         if (insert && chatMessage.speaker) {
             let label = Theatre.instance._getLabelFromInsert(insert);
             let name = label.text;
-            let theatreColor = Theatre.instance.getPlayerFlashColor(chatMessage.user.id, insert.textColor);
             Logger.debug("name is %s", name);
             chatData.speaker.alias = name;
-            // ChatData.flags.theatreColor = theatreColor;
             if (foundry.utils.isNewerVersion(game.version, 12)) {
                 chatData.style = CONST.CHAT_MESSAGE_STYLES.IC;
             } else {
@@ -245,9 +239,7 @@ Hooks.on("preCreateChatMessage", function (chatMessage, data) {
         } else if (insert) {
             let label = Theatre.instance._getLabelFromInsert(insert);
             let name = label.text;
-            let theatreColor = Theatre.instance.getPlayerFlashColor(chatData.user, insert.textColor);
             chatData.speaker.alias = name;
-            // ChatData.flags.theatreColor = theatreColor;
             if (foundry.utils.isNewerVersion(game.version, 12)) {
                 chatData.style = CONST.CHAT_MESSAGE_STYLES.IC;
             } else {
@@ -488,12 +480,12 @@ Hooks.on("createChatMessage", function (chatEntity, _, userId) {
     }
 });
 
-Hooks.on("renderChatMessage", function (ChatMessage, html, data) {
+Hooks.on("renderChatMessageHTML", function (ChatMessage, html, context) {
     if (
         game.settings.get(CONSTANTS.MODULE_ID, "ignoreMessagesToChat") &&
         ChatMessage.flags?.[CONSTANTS.MODULE_ID]?.theatreMessage
     ) {
-        html[0].style.display = "none";
+        html.style.display = "none";
     }
     return true;
 });

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
     "id": "theatre",
     "title": "Theatre Inserts",
     "description": "Theater Inserts with a visual novel style made for heavy roleplay scenes",
-    "version": "3.1.1",
+    "version": "3.3.0",
     "authors": [
         {
             "name": "Ken L"
@@ -150,7 +150,7 @@
     "manifestPlusVersion": "1.2.1",
     "url": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre",
     "manifest": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/latest/download/module.json",
-    "download": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/download/3.1.1/module.zip",
+    "download": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/releases/download/v3.3.0/module.zip",
     "readme": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/blob/master/README.md",
     "changelog": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/blob/master/CHANGELOG.md",
     "bugs": "https://github.com/League-of-Foundry-Developers/fvtt-module-theatre/issues",

--- a/src/scripts/Theatre.js
+++ b/src/scripts/Theatre.js
@@ -2877,7 +2877,7 @@ export class Theatre {
         // no actor is also fine if this is some kind of rigging resource
 
         // src check, not fine at all!
-        if (!(await srcExists(imgSrc))) {
+        if (!(await foundry.canvas.srcExists(imgSrc))) {
             Logger.error("ERROR (_AddTextureResource) : Replacement texture does not exist %s ", false, imgSrc);
             return;
         }
@@ -2939,7 +2939,7 @@ export class Theatre {
 
         // src check, not fine at all!
         for (let src of imgSrcs)
-            if (!(await srcExists(src.imgpath))) {
+            if (!(await foundry.canvas.srcExists(src.imgpath))) {
                 Logger.error("ERROR (_AddAllTextureResources) : Replacement texture does not exist %s ", false, src);
                 return;
             }
@@ -5203,391 +5203,404 @@ export class Theatre {
         let textFlyin = Theatre.FLYIN_ANIMS;
         let textStanding = Theatre.STANDING_ANIMS;
         let sideBar = document.getElementById("sidebar");
-        renderTemplate("modules/theatre/templates/emote_menu.html", {
-            emotes,
-            textFlyin,
-            textStanding,
-            fonts,
-        }).then((template) => {
-            Logger.debug("emote window template rendered");
-            Theatre.instance.theatreEmoteMenu.style.top = `${Theatre.instance.theatreControls.offsetTop - 410}px`;
-            Theatre.instance.theatreEmoteMenu.innerHTML = template;
+        foundry.applications.handlebars
+            .renderTemplate("modules/theatre/templates/emote_menu.html", {
+                emotes,
+                textFlyin,
+                textStanding,
+                fonts,
+            })
+            .then((template) => {
+                Logger.debug("emote window template rendered");
+                Theatre.instance.theatreEmoteMenu.style.top = `${Theatre.instance.theatreControls.offsetTop - 410}px`;
+                Theatre.instance.theatreEmoteMenu.innerHTML = template;
 
-            let wheelFunc = function (ev) {
-                //Logger.debug("wheel on text-box",ev.currentTarget.scrollTop,ev.deltaY,ev.deltaMode);
-                let pos = ev.deltaY > 0;
-                ev.currentTarget.scrollTop += pos ? 10 : -10;
-                ev.preventDefault();
-                ev.stopPropagation();
-            };
-            let wheelFunc2 = function (ev) {
-                //Logger.debug("wheel on text-anim",ev.currentTarget.parentNode.scrollTop,ev.deltaY,ev.deltaMode);
-                let pos = ev.deltaY > 0;
-                ev.currentTarget.parentNode.scrollTop += pos ? 10 : -10;
-                ev.preventDefault();
-                ev.stopPropagation();
-            };
+                let wheelFunc = function (ev) {
+                    //Logger.debug("wheel on text-box",ev.currentTarget.scrollTop,ev.deltaY,ev.deltaMode);
+                    let pos = ev.deltaY > 0;
+                    ev.currentTarget.scrollTop += pos ? 10 : -10;
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                };
+                let wheelFunc2 = function (ev) {
+                    //Logger.debug("wheel on text-anim",ev.currentTarget.parentNode.scrollTop,ev.deltaY,ev.deltaMode);
+                    let pos = ev.deltaY > 0;
+                    ev.currentTarget.parentNode.scrollTop += pos ? 10 : -10;
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                };
 
-            // bind handlers for the font/size/color selectors
-            let sizeSelect = Theatre.instance.theatreEmoteMenu.getElementsByClassName("sizeselect")[0];
-            let colorSelect = Theatre.instance.theatreEmoteMenu.getElementsByClassName("colorselect")[0];
-            let fontSelect = Theatre.instance.theatreEmoteMenu.getElementsByClassName("fontselect")[0];
-            //Logger.debug("Selectors found: ",sizeSelect,colorSelect,fontSelect);
+                // bind handlers for the font/size/color selectors
+                let sizeSelect = Theatre.instance.theatreEmoteMenu.getElementsByClassName("sizeselect")[0];
+                let colorSelect = Theatre.instance.theatreEmoteMenu.getElementsByClassName("colorselect")[0];
+                let fontSelect = Theatre.instance.theatreEmoteMenu.getElementsByClassName("fontselect")[0];
+                //Logger.debug("Selectors found: ",sizeSelect,colorSelect,fontSelect);
 
-            // assign font from insert
-            if (insert && insert.textFont) {
-                //if (fonts.includes(insert.textFont)) fontSelect.value = insert.textFont;
-                //else fontSelect.value = fonts[0];
-                fontSelect.value = insert.textFont;
-            } else if (
-                Theatre.instance.userEmotes[game.user.id] &&
-                Theatre.instance.userEmotes[game.user.id].textFont
-            ) {
-                //if (fonts.includes(Theatre.instance.userEmotes[game.user.id].textFont))
-                //fontSelect.value = Theatre.instance.userEmotes[game.user.id].textFont;
-                //else
-                //fontSelect.value = fonts[0];
-                fontSelect.value = Theatre.instance.userEmotes[game.user.id].textFont;
-                if (insert) insert.textFont = fontSelect.value;
-            } else {
-                fontSelect.value = fonts[0];
-            }
-            // assign color from insert
-            if (insert && insert.textColor) {
-                colorSelect.value = insert.textColor;
-            } else if (
-                Theatre.instance.userEmotes[game.user.id] &&
-                Theatre.instance.userEmotes[game.user.id].textColor
-            ) {
-                colorSelect.value = Theatre.instance.userEmotes[game.user.id].textColor;
-                if (insert) insert.textColor = colorSelect.value;
-            }
-            // assgin font size
-            let sizeIcon = document.createElement("div");
-            let sizeValue = 2;
-            if (insert) sizeValue = insert.textSize;
-            else if (Theatre.instance.userEmotes[game.user.id])
-                sizeValue = Number(Theatre.instance.userEmotes[game.user.id].textSize);
-
-            switch (sizeValue) {
-                case 3:
-                    KHelpers.addClass(sizeIcon, "theatre-icon-fontsize-large");
-                    break;
-                case 1:
-                    KHelpers.addClass(sizeIcon, "theatre-icon-fontsize-small");
-                    break;
-                default:
-                    KHelpers.addClass(sizeIcon, "theatre-icon-fontsize-medium");
-                    break;
-            }
-            sizeSelect.appendChild(sizeIcon);
-
-            sizeSelect.addEventListener("click", (ev) => {
-                let insert = Theatre.instance.getInsertById(Theatre.instance.speakingAs);
-                let icon = sizeSelect.children[0];
-                let value = 2;
-                if (insert) value = insert.textSize;
+                // assign font from insert
+                if (insert && insert.textFont) {
+                    //if (fonts.includes(insert.textFont)) fontSelect.value = insert.textFont;
+                    //else fontSelect.value = fonts[0];
+                    fontSelect.value = insert.textFont;
+                } else if (
+                    Theatre.instance.userEmotes[game.user.id] &&
+                    Theatre.instance.userEmotes[game.user.id].textFont
+                ) {
+                    //if (fonts.includes(Theatre.instance.userEmotes[game.user.id].textFont))
+                    //fontSelect.value = Theatre.instance.userEmotes[game.user.id].textFont;
+                    //else
+                    //fontSelect.value = fonts[0];
+                    fontSelect.value = Theatre.instance.userEmotes[game.user.id].textFont;
+                    if (insert) insert.textFont = fontSelect.value;
+                } else {
+                    fontSelect.value = fonts[0];
+                }
+                // assign color from insert
+                if (insert && insert.textColor) {
+                    colorSelect.value = insert.textColor;
+                } else if (
+                    Theatre.instance.userEmotes[game.user.id] &&
+                    Theatre.instance.userEmotes[game.user.id].textColor
+                ) {
+                    colorSelect.value = Theatre.instance.userEmotes[game.user.id].textColor;
+                    if (insert) insert.textColor = colorSelect.value;
+                }
+                // assgin font size
+                let sizeIcon = document.createElement("div");
+                let sizeValue = 2;
+                if (insert) sizeValue = insert.textSize;
                 else if (Theatre.instance.userEmotes[game.user.id])
-                    value = Number(Theatre.instance.userEmotes[game.user.id].textSize);
+                    sizeValue = Number(Theatre.instance.userEmotes[game.user.id].textSize);
 
-                switch (value) {
+                switch (sizeValue) {
                     case 3:
-                        KHelpers.removeClass(icon, "theatre-icon-fontsize-large");
-                        KHelpers.addClass(icon, "theatre-icon-fontsize-medium");
-                        value = 2;
+                        KHelpers.addClass(sizeIcon, "theatre-icon-fontsize-large");
                         break;
                     case 1:
-                        KHelpers.removeClass(icon, "theatre-icon-fontsize-small");
-                        KHelpers.addClass(icon, "theatre-icon-fontsize-large");
-                        value = 3;
+                        KHelpers.addClass(sizeIcon, "theatre-icon-fontsize-small");
                         break;
                     default:
-                        KHelpers.removeClass(icon, "theatre-icon-fontsize-medium");
-                        KHelpers.addClass(icon, "theatre-icon-fontsize-small");
-                        value = 1;
+                        KHelpers.addClass(sizeIcon, "theatre-icon-fontsize-medium");
                         break;
                 }
-                Theatre.instance.setUserEmote(game.user.id, Theatre.instance.speakingAs, "textsize", value);
-            });
-            fontSelect.addEventListener("change", (ev) => {
-                Theatre.instance.setUserEmote(
-                    game.user.id,
-                    Theatre.instance.speakingAs,
-                    "textfont",
-                    ev.currentTarget.value,
-                );
-                Theatre.instance.renderEmoteMenu();
-            });
-            colorSelect.addEventListener("change", (ev) => {
-                Theatre.instance.setUserEmote(
-                    game.user.id,
-                    Theatre.instance.speakingAs,
-                    "textcolor",
-                    ev.currentTarget.value,
-                );
-            });
+                sizeSelect.appendChild(sizeIcon);
 
-            // Apply our language specific fonts to the template
-            // OR apply the font specified by the insert
-            let headers = Theatre.instance.theatreEmoteMenu.getElementsByTagName("h2");
-            let textAnims = Theatre.instance.theatreEmoteMenu.getElementsByClassName("textanim");
-            for (let e of headers) Theatre.instance._applyFontFamily(e, Theatre.instance.titleFont);
-            for (let e of textAnims) {
-                let font = fontSelect.value;
-                Theatre.instance._applyFontFamily(e, font);
-                e.addEventListener("wheel", wheelFunc2);
-            }
+                sizeSelect.addEventListener("click", (ev) => {
+                    let insert = Theatre.instance.getInsertById(Theatre.instance.speakingAs);
+                    let icon = sizeSelect.children[0];
+                    let value = 2;
+                    if (insert) value = insert.textSize;
+                    else if (Theatre.instance.userEmotes[game.user.id])
+                        value = Number(Theatre.instance.userEmotes[game.user.id].textSize);
 
-            // bind click listeners for the textanim elements to animate a preview
-            // hover-off will reset the text content
-            let flyinBox = Theatre.instance.theatreEmoteMenu.getElementsByClassName("textflyin-box")[0];
-            flyinBox = flyinBox.getElementsByClassName("theatre-container-column")[0];
-            let standingBox = Theatre.instance.theatreEmoteMenu.getElementsByClassName("textstanding-box")[0];
-            standingBox = standingBox.getElementsByClassName("theatre-container-column")[0];
-
-            flyinBox.addEventListener("wheel", wheelFunc);
-            standingBox.addEventListener("wheel", wheelFunc);
-
-            for (let child of flyinBox.children) {
-                // get animation function
-                // bind annonomous click listener
-                child.addEventListener("mouseover", (ev) => {
-                    let text = ev.currentTarget.getAttribute("otext");
-                    let anim = ev.currentTarget.getAttribute("name");
-                    //Logger.debug("child text: ",text,ev.currentTarget);
-                    ev.currentTarget.textContent = "";
-                    let charSpans = Theatre.splitTextBoxToChars(text, ev.currentTarget);
-                    textFlyin[anim].func.call(this, charSpans, 0.5, 0.05, null);
+                    switch (value) {
+                        case 3:
+                            KHelpers.removeClass(icon, "theatre-icon-fontsize-large");
+                            KHelpers.addClass(icon, "theatre-icon-fontsize-medium");
+                            value = 2;
+                            break;
+                        case 1:
+                            KHelpers.removeClass(icon, "theatre-icon-fontsize-small");
+                            KHelpers.addClass(icon, "theatre-icon-fontsize-large");
+                            value = 3;
+                            break;
+                        default:
+                            KHelpers.removeClass(icon, "theatre-icon-fontsize-medium");
+                            KHelpers.addClass(icon, "theatre-icon-fontsize-small");
+                            value = 1;
+                            break;
+                    }
+                    Theatre.instance.setUserEmote(game.user.id, Theatre.instance.speakingAs, "textsize", value);
                 });
-                child.addEventListener("mouseout", (ev) => {
-                    for (let c of ev.currentTarget.children) {
-                        for (let sc of c.children) TweenMax.killTweensOf(sc);
-                        TweenMax.killTweensOf(c);
-                    }
-                    for (let c of ev.currentTarget.children) c.parentNode.removeChild(c);
-                    TweenMax.killTweensOf(child);
-                    child.style["overflow-y"] = "scroll";
-                    child.style["overflow-x"] = "hidden";
-                    //Logger.debug("all tweens",TweenMax.getAllTweens());
-                    ev.currentTarget.textContent = ev.currentTarget.getAttribute("otext");
+                fontSelect.addEventListener("change", (ev) => {
+                    Theatre.instance.setUserEmote(
+                        game.user.id,
+                        Theatre.instance.speakingAs,
+                        "textfont",
+                        ev.currentTarget.value,
+                    );
+                    Theatre.instance.renderEmoteMenu();
                 });
-                // bind text anim type
-                child.addEventListener("mouseup", (ev) => {
-                    if (ev.button == 0) {
-                        if (KHelpers.hasClass(ev.currentTarget, "textflyin-active")) {
-                            KHelpers.removeClass(ev.currentTarget, "textflyin-active");
-                            Theatre.instance.setUserEmote(game.user.id, Theatre.instance.speakingAs, "textflyin", null);
-                        } else {
-                            let lastActives =
-                                Theatre.instance.theatreEmoteMenu.getElementsByClassName("textflyin-active");
-                            for (let la of lastActives) KHelpers.removeClass(la, "textflyin-active");
-                            //if (insert || Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
-                            KHelpers.addClass(ev.currentTarget, "textflyin-active");
-                            Theatre.instance.setUserEmote(
-                                game.user.id,
-                                Theatre.instance.speakingAs,
-                                "textflyin",
-                                ev.currentTarget.getAttribute("name"),
-                            );
-                            //}
-                        }
-                        // push focus to chat-message
-                        let chatMessage = document.getElementById("chat-message");
-                        chatMessage.focus();
-                    }
-                });
-                // check if this child is our configured 'text style'
-                let childTextMode = child.getAttribute("name");
-                if (insert) {
-                    let insertTextMode = insert.textFlyin;
-                    if (insertTextMode && insertTextMode == childTextMode) {
-                        KHelpers.addClass(child, "textflyin-active");
-                        // scroll to
-                        //TweenMax.to(flyinBox,.4,{scrollTo:{y:child.offsetTop, offsetY:flyinBox.offsetHeight/2}})
-                        flyinBox.scrollTop = child.offsetTop - Math.max(flyinBox.offsetHeight / 2, 0);
-                    }
-                } else if (Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
-                    let insertTextMode = Theatre.instance.theatreNarrator.getAttribute("textflyin");
-                    if (insertTextMode && insertTextMode == childTextMode) {
-                        KHelpers.addClass(child, "textflyin-active");
-                        // scroll to
-                        //TweenMax.to(flyinBox,.4,{scrollTo:{y:child.offsetTop, offsetY:flyinBox.offsetHeight/2}})
-                        flyinBox.scrollTop = child.offsetTop - Math.max(flyinBox.offsetHeight / 2, 0);
-                    }
-                } else if (
-                    !insert &&
-                    Theatre.instance.userEmotes[game.user.id] &&
-                    child.getAttribute("name") == Theatre.instance.userEmotes[game.user.id].textFlyin
-                ) {
-                    KHelpers.addClass(child, "textflyin-active");
-                    // scroll to
-                    //TweenMax.to(flyinBox,.4,{scrollTo:{y:child.offsetTop, offsetY:flyinBox.offsetHeight/2}})
-                    flyinBox.scrollTop = child.offsetTop - Math.max(flyinBox.offsetHeight / 2, 0);
-                }
-            }
-
-            for (let child of standingBox.children) {
-                // get animation function
-                // bind annonomous click listener
-                child.addEventListener("mouseover", (ev) => {
-                    let text = ev.currentTarget.getAttribute("otext");
-                    let anim = ev.currentTarget.getAttribute("name");
-                    //Logger.debug("child text: ",text,ev.currentTarget);
-                    ev.currentTarget.textContent = "";
-                    let charSpans = Theatre.splitTextBoxToChars(text, ev.currentTarget);
-                    textFlyin["typewriter"].func.call(
-                        this,
-                        charSpans,
-                        0.5,
-                        0.05,
-                        textStanding[anim] ? textStanding[anim].func : null,
+                colorSelect.addEventListener("change", (ev) => {
+                    Theatre.instance.setUserEmote(
+                        game.user.id,
+                        Theatre.instance.speakingAs,
+                        "textcolor",
+                        ev.currentTarget.value,
                     );
                 });
-                child.addEventListener("mouseout", (ev) => {
-                    for (let c of ev.currentTarget.children) {
-                        for (let sc of c.children) TweenMax.killTweensOf(sc);
-                        TweenMax.killTweensOf(c);
-                    }
-                    for (let c of ev.currentTarget.children) c.parentNode.removeChild(c);
-                    TweenMax.killTweensOf(child);
-                    child.style["overflow-y"] = "scroll";
-                    child.style["overflow-x"] = "hidden";
-                    //Logger.debug("all tweens",TweenMax.getAllTweens());
-                    ev.currentTarget.textContent = ev.currentTarget.getAttribute("otext");
-                });
-                // bind text anim type
-                child.addEventListener("mouseup", (ev) => {
-                    if (ev.button == 0) {
-                        if (KHelpers.hasClass(ev.currentTarget, "textstanding-active")) {
-                            KHelpers.removeClass(ev.currentTarget, "textstanding-active");
-                            Theatre.instance.setUserEmote(
-                                game.user.id,
-                                Theatre.instance.speakingAs,
-                                "textstanding",
-                                null,
-                            );
-                        } else {
-                            let lastActives =
-                                Theatre.instance.theatreEmoteMenu.getElementsByClassName("textstanding-active");
-                            for (let la of lastActives) KHelpers.removeClass(la, "textstanding-active");
-                            //if (insert || Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
-                            KHelpers.addClass(ev.currentTarget, "textstanding-active");
-                            Theatre.instance.setUserEmote(
-                                game.user.id,
-                                Theatre.instance.speakingAs,
-                                "textstanding",
-                                ev.currentTarget.getAttribute("name"),
-                            );
-                            //}
-                        }
-                        // push focus to chat-message
-                        let chatMessage = document.getElementById("chat-message");
-                        chatMessage.focus();
-                    }
-                });
-                // check if this child is our configured 'text style'
-                let childTextMode = child.getAttribute("name");
-                if (insert) {
-                    let insertTextMode = insert.textStanding;
-                    if (insertTextMode && insertTextMode == childTextMode) {
-                        KHelpers.addClass(child, "textstanding-active");
-                        //TweenMax.to(standingBox,.4,{scrollTo:{y:child.offsetTop, offsetY:standingBox.offsetHeight/2}})
-                        standingBox.scrollTop = child.offsetTop - Math.max(standingBox.offsetHeight / 2, 0);
-                    }
-                } else if (Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
-                    let insertTextMode = Theatre.instance.theatreNarrator.getAttribute("textstanding");
-                    if (insertTextMode && insertTextMode == childTextMode) {
-                        KHelpers.addClass(child, "textstanding-active");
-                        // scroll to
-                        //TweenMax.to(standingBox,.4,{scrollTo:{y:child.offsetTop, offsetY:standingBox.offsetHeight/2}})
-                        standingBox.scrollTop = child.offsetTop - Math.max(standingBox.offsetHeight / 2, 0);
-                    }
-                } else if (
-                    Theatre.instance.userEmotes[game.user.id] &&
-                    child.getAttribute("name") == Theatre.instance.userEmotes[game.user.id].textStanding
-                ) {
-                    KHelpers.addClass(child, "textstanding-active");
-                    // scroll to
-                    //TweenMax.to(standingBox,.4,{scrollTo:{y:child.offsetTop, offsetY:standingBox.offsetHeight/2}})
-                    standingBox.scrollTop = child.offsetTop - Math.max(standingBox.offsetHeight / 2, 0);
-                }
-            }
 
-            // If speaking as theatre, minimize away the emote section
-            let emoteBox = Theatre.instance.theatreEmoteMenu.getElementsByClassName("emote-box")[0];
-            let emContainer = emoteBox.getElementsByClassName("theatre-container-tiles")[0];
-            if (Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
-                emoteBox.style.cssText += "flex: 0 0 40px";
-                let emLabel = emoteBox.getElementsByTagName("h2")[0];
-                fontSelect.style["max-width"] = "unset";
-                emContainer.style.display = "none";
-                emLabel.style.display = "none";
-            } else {
-                // configure handles to bind emote selection
-                let emoteBtns = Theatre.instance.theatreEmoteMenu.getElementsByClassName("emote");
-                for (let child of emoteBtns) {
-                    //bind annomous click listener
+                // Apply our language specific fonts to the template
+                // OR apply the font specified by the insert
+                let headers = Theatre.instance.theatreEmoteMenu.getElementsByTagName("h2");
+                let textAnims = Theatre.instance.theatreEmoteMenu.getElementsByClassName("textanim");
+                for (let e of headers) Theatre.instance._applyFontFamily(e, Theatre.instance.titleFont);
+                for (let e of textAnims) {
+                    let font = fontSelect.value;
+                    Theatre.instance._applyFontFamily(e, font);
+                    e.addEventListener("wheel", wheelFunc2);
+                }
+
+                // bind click listeners for the textanim elements to animate a preview
+                // hover-off will reset the text content
+                let flyinBox = Theatre.instance.theatreEmoteMenu.getElementsByClassName("textflyin-box")[0];
+                flyinBox = flyinBox.getElementsByClassName("theatre-container-column")[0];
+                let standingBox = Theatre.instance.theatreEmoteMenu.getElementsByClassName("textstanding-box")[0];
+                standingBox = standingBox.getElementsByClassName("theatre-container-column")[0];
+
+                flyinBox.addEventListener("wheel", wheelFunc);
+                standingBox.addEventListener("wheel", wheelFunc);
+
+                for (let child of flyinBox.children) {
+                    // get animation function
+                    // bind annonomous click listener
+                    child.addEventListener("mouseover", (ev) => {
+                        let text = ev.currentTarget.getAttribute("otext");
+                        let anim = ev.currentTarget.getAttribute("name");
+                        //Logger.debug("child text: ",text,ev.currentTarget);
+                        ev.currentTarget.textContent = "";
+                        let charSpans = Theatre.splitTextBoxToChars(text, ev.currentTarget);
+                        textFlyin[anim].func.call(this, charSpans, 0.5, 0.05, null);
+                    });
+                    child.addEventListener("mouseout", (ev) => {
+                        for (let c of ev.currentTarget.children) {
+                            for (let sc of c.children) TweenMax.killTweensOf(sc);
+                            TweenMax.killTweensOf(c);
+                        }
+                        for (let c of ev.currentTarget.children) c.parentNode.removeChild(c);
+                        TweenMax.killTweensOf(child);
+                        child.style["overflow-y"] = "scroll";
+                        child.style["overflow-x"] = "hidden";
+                        //Logger.debug("all tweens",TweenMax.getAllTweens());
+                        ev.currentTarget.textContent = ev.currentTarget.getAttribute("otext");
+                    });
+                    // bind text anim type
                     child.addEventListener("mouseup", (ev) => {
                         if (ev.button == 0) {
-                            let emName = ev.currentTarget.getAttribute("name");
-                            Logger.debug("em name: %s was clicked", emName);
-                            if (KHelpers.hasClass(ev.currentTarget, "emote-active")) {
-                                KHelpers.removeClass(ev.currentTarget, "emote-active");
-                                // if speaking set to base
-                                Theatre.instance.setUserEmote(game.user.id, Theatre.instance.speakingAs, "emote", null);
-                            } else {
-                                let lastActives =
-                                    Theatre.instance.theatreEmoteMenu.getElementsByClassName("emote-active");
-                                for (let la of lastActives) KHelpers.removeClass(la, "emote-active");
-                                KHelpers.addClass(ev.currentTarget, "emote-active");
-                                // if speaking, then set our emote!
+                            if (KHelpers.hasClass(ev.currentTarget, "textflyin-active")) {
+                                KHelpers.removeClass(ev.currentTarget, "textflyin-active");
                                 Theatre.instance.setUserEmote(
                                     game.user.id,
                                     Theatre.instance.speakingAs,
-                                    "emote",
-                                    emName,
+                                    "textflyin",
+                                    null,
                                 );
+                            } else {
+                                let lastActives =
+                                    Theatre.instance.theatreEmoteMenu.getElementsByClassName("textflyin-active");
+                                for (let la of lastActives) KHelpers.removeClass(la, "textflyin-active");
+                                //if (insert || Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
+                                KHelpers.addClass(ev.currentTarget, "textflyin-active");
+                                Theatre.instance.setUserEmote(
+                                    game.user.id,
+                                    Theatre.instance.speakingAs,
+                                    "textflyin",
+                                    ev.currentTarget.getAttribute("name"),
+                                );
+                                //}
                             }
                             // push focus to chat-message
                             let chatMessage = document.getElementById("chat-message");
                             chatMessage.focus();
                         }
                     });
-                    // bind mouseenter Listener
-                    child.addEventListener("mouseenter", (ev) => {
-                        Theatre.instance.configureTheatreToolTip(
-                            Theatre.instance.speakingAs,
-                            ev.currentTarget.getAttribute("name"),
+                    // check if this child is our configured 'text style'
+                    let childTextMode = child.getAttribute("name");
+                    if (insert) {
+                        let insertTextMode = insert.textFlyin;
+                        if (insertTextMode && insertTextMode == childTextMode) {
+                            KHelpers.addClass(child, "textflyin-active");
+                            // scroll to
+                            //TweenMax.to(flyinBox,.4,{scrollTo:{y:child.offsetTop, offsetY:flyinBox.offsetHeight/2}})
+                            flyinBox.scrollTop = child.offsetTop - Math.max(flyinBox.offsetHeight / 2, 0);
+                        }
+                    } else if (Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
+                        let insertTextMode = Theatre.instance.theatreNarrator.getAttribute("textflyin");
+                        if (insertTextMode && insertTextMode == childTextMode) {
+                            KHelpers.addClass(child, "textflyin-active");
+                            // scroll to
+                            //TweenMax.to(flyinBox,.4,{scrollTo:{y:child.offsetTop, offsetY:flyinBox.offsetHeight/2}})
+                            flyinBox.scrollTop = child.offsetTop - Math.max(flyinBox.offsetHeight / 2, 0);
+                        }
+                    } else if (
+                        !insert &&
+                        Theatre.instance.userEmotes[game.user.id] &&
+                        child.getAttribute("name") == Theatre.instance.userEmotes[game.user.id].textFlyin
+                    ) {
+                        KHelpers.addClass(child, "textflyin-active");
+                        // scroll to
+                        //TweenMax.to(flyinBox,.4,{scrollTo:{y:child.offsetTop, offsetY:flyinBox.offsetHeight/2}})
+                        flyinBox.scrollTop = child.offsetTop - Math.max(flyinBox.offsetHeight / 2, 0);
+                    }
+                }
+
+                for (let child of standingBox.children) {
+                    // get animation function
+                    // bind annonomous click listener
+                    child.addEventListener("mouseover", (ev) => {
+                        let text = ev.currentTarget.getAttribute("otext");
+                        let anim = ev.currentTarget.getAttribute("name");
+                        //Logger.debug("child text: ",text,ev.currentTarget);
+                        ev.currentTarget.textContent = "";
+                        let charSpans = Theatre.splitTextBoxToChars(text, ev.currentTarget);
+                        textFlyin["typewriter"].func.call(
+                            this,
+                            charSpans,
+                            0.5,
+                            0.05,
+                            textStanding[anim] ? textStanding[anim].func : null,
                         );
                     });
-                    // check if this child is our configured 'emote'
-                    let childEmote = child.getAttribute("name");
+                    child.addEventListener("mouseout", (ev) => {
+                        for (let c of ev.currentTarget.children) {
+                            for (let sc of c.children) TweenMax.killTweensOf(sc);
+                            TweenMax.killTweensOf(c);
+                        }
+                        for (let c of ev.currentTarget.children) c.parentNode.removeChild(c);
+                        TweenMax.killTweensOf(child);
+                        child.style["overflow-y"] = "scroll";
+                        child.style["overflow-x"] = "hidden";
+                        //Logger.debug("all tweens",TweenMax.getAllTweens());
+                        ev.currentTarget.textContent = ev.currentTarget.getAttribute("otext");
+                    });
+                    // bind text anim type
+                    child.addEventListener("mouseup", (ev) => {
+                        if (ev.button == 0) {
+                            if (KHelpers.hasClass(ev.currentTarget, "textstanding-active")) {
+                                KHelpers.removeClass(ev.currentTarget, "textstanding-active");
+                                Theatre.instance.setUserEmote(
+                                    game.user.id,
+                                    Theatre.instance.speakingAs,
+                                    "textstanding",
+                                    null,
+                                );
+                            } else {
+                                let lastActives =
+                                    Theatre.instance.theatreEmoteMenu.getElementsByClassName("textstanding-active");
+                                for (let la of lastActives) KHelpers.removeClass(la, "textstanding-active");
+                                //if (insert || Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
+                                KHelpers.addClass(ev.currentTarget, "textstanding-active");
+                                Theatre.instance.setUserEmote(
+                                    game.user.id,
+                                    Theatre.instance.speakingAs,
+                                    "textstanding",
+                                    ev.currentTarget.getAttribute("name"),
+                                );
+                                //}
+                            }
+                            // push focus to chat-message
+                            let chatMessage = document.getElementById("chat-message");
+                            chatMessage.focus();
+                        }
+                    });
+                    // check if this child is our configured 'text style'
+                    let childTextMode = child.getAttribute("name");
                     if (insert) {
-                        // if we have an insert we're speaking through, we should get that emote state instead
-                        // if the insert has no emote state, neither should we despite user settings
-                        let insertEmote = insert.emote;
-                        if (insertEmote && insertEmote == childEmote) {
+                        let insertTextMode = insert.textStanding;
+                        if (insertTextMode && insertTextMode == childTextMode) {
+                            KHelpers.addClass(child, "textstanding-active");
+                            //TweenMax.to(standingBox,.4,{scrollTo:{y:child.offsetTop, offsetY:standingBox.offsetHeight/2}})
+                            standingBox.scrollTop = child.offsetTop - Math.max(standingBox.offsetHeight / 2, 0);
+                        }
+                    } else if (Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
+                        let insertTextMode = Theatre.instance.theatreNarrator.getAttribute("textstanding");
+                        if (insertTextMode && insertTextMode == childTextMode) {
+                            KHelpers.addClass(child, "textstanding-active");
+                            // scroll to
+                            //TweenMax.to(standingBox,.4,{scrollTo:{y:child.offsetTop, offsetY:standingBox.offsetHeight/2}})
+                            standingBox.scrollTop = child.offsetTop - Math.max(standingBox.offsetHeight / 2, 0);
+                        }
+                    } else if (
+                        Theatre.instance.userEmotes[game.user.id] &&
+                        child.getAttribute("name") == Theatre.instance.userEmotes[game.user.id].textStanding
+                    ) {
+                        KHelpers.addClass(child, "textstanding-active");
+                        // scroll to
+                        //TweenMax.to(standingBox,.4,{scrollTo:{y:child.offsetTop, offsetY:standingBox.offsetHeight/2}})
+                        standingBox.scrollTop = child.offsetTop - Math.max(standingBox.offsetHeight / 2, 0);
+                    }
+                }
+
+                // If speaking as theatre, minimize away the emote section
+                let emoteBox = Theatre.instance.theatreEmoteMenu.getElementsByClassName("emote-box")[0];
+                let emContainer = emoteBox.getElementsByClassName("theatre-container-tiles")[0];
+                if (Theatre.instance.speakingAs == CONSTANTS.NARRATOR) {
+                    emoteBox.style.cssText += "flex: 0 0 40px";
+                    let emLabel = emoteBox.getElementsByTagName("h2")[0];
+                    fontSelect.style["max-width"] = "unset";
+                    emContainer.style.display = "none";
+                    emLabel.style.display = "none";
+                } else {
+                    // configure handles to bind emote selection
+                    let emoteBtns = Theatre.instance.theatreEmoteMenu.getElementsByClassName("emote");
+                    for (let child of emoteBtns) {
+                        //bind annomous click listener
+                        child.addEventListener("mouseup", (ev) => {
+                            if (ev.button == 0) {
+                                let emName = ev.currentTarget.getAttribute("name");
+                                Logger.debug("em name: %s was clicked", emName);
+                                if (KHelpers.hasClass(ev.currentTarget, "emote-active")) {
+                                    KHelpers.removeClass(ev.currentTarget, "emote-active");
+                                    // if speaking set to base
+                                    Theatre.instance.setUserEmote(
+                                        game.user.id,
+                                        Theatre.instance.speakingAs,
+                                        "emote",
+                                        null,
+                                    );
+                                } else {
+                                    let lastActives =
+                                        Theatre.instance.theatreEmoteMenu.getElementsByClassName("emote-active");
+                                    for (let la of lastActives) KHelpers.removeClass(la, "emote-active");
+                                    KHelpers.addClass(ev.currentTarget, "emote-active");
+                                    // if speaking, then set our emote!
+                                    Theatre.instance.setUserEmote(
+                                        game.user.id,
+                                        Theatre.instance.speakingAs,
+                                        "emote",
+                                        emName,
+                                    );
+                                }
+                                // push focus to chat-message
+                                let chatMessage = document.getElementById("chat-message");
+                                chatMessage.focus();
+                            }
+                        });
+                        // bind mouseenter Listener
+                        child.addEventListener("mouseenter", (ev) => {
+                            Theatre.instance.configureTheatreToolTip(
+                                Theatre.instance.speakingAs,
+                                ev.currentTarget.getAttribute("name"),
+                            );
+                        });
+                        // check if this child is our configured 'emote'
+                        let childEmote = child.getAttribute("name");
+                        if (insert) {
+                            // if we have an insert we're speaking through, we should get that emote state instead
+                            // if the insert has no emote state, neither should we despite user settings
+                            let insertEmote = insert.emote;
+                            if (insertEmote && insertEmote == childEmote) {
+                                KHelpers.addClass(child, "emote-active");
+                                //emContainer.scrollTop = child.offsetTop-Math.max(emContainer.offsetHeight/2,0);
+                            }
+                            // we should 'highlight' emotes that at least have a base insert
+                            if (emotes[childEmote] && emotes[childEmote].insert)
+                                KHelpers.addClass(child, "emote-imgavail");
+                        }
+                        if (
+                            !insert &&
+                            Theatre.instance.userEmotes[game.user.id] &&
+                            childEmote == Theatre.instance.userEmotes[game.user.id].emote
+                        ) {
                             KHelpers.addClass(child, "emote-active");
                             //emContainer.scrollTop = child.offsetTop-Math.max(emContainer.offsetHeight/2,0);
                         }
-                        // we should 'highlight' emotes that at least have a base insert
-                        if (emotes[childEmote] && emotes[childEmote].insert) KHelpers.addClass(child, "emote-imgavail");
                     }
-                    if (
-                        !insert &&
-                        Theatre.instance.userEmotes[game.user.id] &&
-                        childEmote == Theatre.instance.userEmotes[game.user.id].emote
-                    ) {
-                        KHelpers.addClass(child, "emote-active");
-                        //emContainer.scrollTop = child.offsetTop-Math.max(emContainer.offsetHeight/2,0);
-                    }
+                    // bind mouseleave Listener
+                    emoteBtns[0].parentNode.addEventListener("mouseleave", (ev) => {
+                        Theatre.instance.theatreToolTip.style.opacity = 0;
+                    });
                 }
-                // bind mouseleave Listener
-                emoteBtns[0].parentNode.addEventListener("mouseleave", (ev) => {
-                    Theatre.instance.theatreToolTip.style.opacity = 0;
-                });
-            }
-        });
+            });
     }
 
     /**
@@ -5707,8 +5720,8 @@ export class Theatre {
      * @param ev (Event) : The Event that triggered this handler
      */
     handleChatMessageKeyDown(ev) {
-        const context = KeyboardManager.getKeyboardEventContext(ev);
-        const actions = KeyboardManager._getMatchingActions(context);
+        const context = foundry.helpers.interaction.KeyboardManager.getKeyboardEventContext(ev);
+        const actions = foundry.helpers.interaction.KeyboardManager._getMatchingActions(context);
         for (const action of actions) {
             if (!action.action.includes(CONSTANTS.MODULE_ID)) {
                 continue;

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -5,14 +5,6 @@ import Logger from "./lib/Logger.js";
 
 export const registerSettings = function () {
     let settingsCustom = {};
-    // game.settings.registerMenu(CONSTANTS.MODULE_ID, "resetAllSettings", {
-    // 	name: `${CONSTANTS.MODULE_ID}.setting.reset.name`,
-    // 	hint: `${CONSTANTS.MODULE_ID}.setting.reset.hint`,
-    // 	icon: "fas fa-coins",
-    // 	type: ResetSettingsDialog,
-    // 	restricted: true,
-    // });
-    // =====================================================================
 
     game.settings.register(CONSTANTS.MODULE_ID, "gmOnly", {
         name: "Theatre.UI.Settings.gmOnly",
@@ -301,46 +293,6 @@ export const registerSettings = function () {
 
     return settingsCustom;
 };
-
-class ResetSettingsDialog extends FormApplication {
-    constructor(...args) {
-        //@ts-ignore
-        super(...args);
-        //@ts-ignore
-        return new Dialog({
-            title: game.i18n.localize(`${CONSTANTS.MODULE_ID}.dialogs.resetsettings.title`),
-            content:
-                '<p style="margin-bottom:1rem;">' +
-                game.i18n.localize(`${CONSTANTS.MODULE_ID}.dialogs.resetsettings.content`) +
-                "</p>",
-            buttons: {
-                confirm: {
-                    icon: '<i class="fas fa-check"></i>',
-                    label: game.i18n.localize(`${CONSTANTS.MODULE_ID}.dialogs.resetsettings.confirm`),
-                    callback: async () => {
-                        const worldSettings = game.settings.storage
-                            ?.get("world")
-                            ?.filter((setting) => setting.key.startsWith(`${CONSTANTS.MODULE_ID}.`));
-                        for (let setting of worldSettings) {
-                            console.log(`Reset setting '${setting.key}'`);
-                            await setting.delete();
-                        }
-                        //window.location.reload();
-                    },
-                },
-                cancel: {
-                    icon: '<i class="fas fa-times"></i>',
-                    label: game.i18n.localize(`${CONSTANTS.MODULE_ID}.dialogs.resetsettings.cancel`),
-                },
-            },
-            default: "cancel",
-        });
-    }
-
-    async _updateObject(event, formData) {
-        // do nothing
-    }
-}
 
 export const registerKeybindings = function () {
     game.keybindings.register(CONSTANTS.MODULE_ID, "unfocusTextArea", {

--- a/src/scripts/theatre-helpers.js
+++ b/src/scripts/theatre-helpers.js
@@ -2201,7 +2201,8 @@ export class TheatreHelpers {
             actorSheet.actor.flags.theatre = { baseinsert: "", name: "" };
         }
 
-        new TheatreActorConfig(actorSheet.actor, {
+        new TheatreActorConfig({
+            document: actorSheet.actor,
             top: actorSheet.position.top + 40,
             left: actorSheet.position.left + (actorSheet.position.width - 500) / 2,
             configureDefault: true,

--- a/src/styles/theatre.css
+++ b/src/styles/theatre.css
@@ -1650,14 +1650,12 @@
   width: 50%;
   height: 30px;
   margin: 2px 2px;
-  background: rgba(255, 255, 255, 0.75);
   box-sizing: border-box;
   border: 1px solid #aaa;
   border-radius: 3px;
   padding: 1px 6px;
   align-items: flex-start;
   text-align: center;
-  cursor: default;
   font-size: 14px;
   line-height: 28px;
   font-family: "Signika";
@@ -1665,6 +1663,10 @@
 
 .theatre-config-btn-add-emote:hover {
   box-shadow: 0 0 5px red;
+}
+
+.theatre-config-btn-submit{
+    margin-top: 20px;
 }
 
 .theatre-config-btn-edit-emote {

--- a/src/templates/theatre_actor_config.html
+++ b/src/templates/theatre_actor_config.html
@@ -1,71 +1,106 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
-    <div class="theatre-config-tab-pane">
-        <nav class="sheet-tabs tabs theatre-config-tabs" data-group="theatre-tabs">
-            <a class="item" data-tab="main">
-                <i class="fas fa-user"></i> {{localize "Theatre.UI.Config.Main"}}
-            </a>
-            <a class="item" data-tab="emotes">
-                <i class="far fa-laugh"></i> {{localize "Theatre.Emote.Label"}}
-            </a>
-        </nav>
-        <section class="theatre-config-contents">
-            <div class="tab theatre-config-tab no-scrollbar" data-tab="main" data-group="theatre-tabs">
-                <p class="notes">{{localize "Theatre.UI.Config.InsertName"}}</p>
-                <div class="form-group"><input name="flags.theatre.name" placeholder="{{object.name}}"
-                        value="{{object.flags.theatre.name}}" /></div>
-                <p class="notes"> {{localize "Theatre.UI.Config.SetTopAlign"}}</p>
-                <div class="form-group"><select name="flags.theatre.optalign"
-                        data-dtype="String">{{#select object.flags.theatre.optalign}}
-                            <option value="top">{{localize "Theatre.UI.Config.SetTopAlignTop"}}</option>
-                            <option value="bottom">{{localize "Theatre.UI.Config.SetTopAlignBottom"}}</option>
-                        {{/select}}</select></div>
-                <p class="notes"> {{localize "Theatre.UI.Config.SetDefaultInsert"}}</p>
-                <div class="form-group">
-                    <label>{{localize "Theatre.UI.Config.BaseInsert"}}</label>{{filePicker type="imagevideo" target="flags.theatre.baseinsert"}}<input
-                        class="image" type="text" name="flags.theatre.baseinsert" placeholder="{{object.img}}"
-                        value="{{object.flags.theatre.baseinsert}}" data-dtype="String" /></div>
+<div class="theatre-config-tab-pane">
+    <section class="theatre-config-contents">
+        <section
+            class="tab theatre-config-tab no-scrollbar {{tabs.main.id}} {{tabs.main.cssClass}}"
+            data-tab="{{tabs.main.id}}"
+            data-group="{{tabs.main.group}}"
+        >
+            <p class="notes">{{localize "Theatre.UI.Config.InsertName"}}</p>
+            <div class="form-group">
+                <input
+                    type="text"
+                    name="flags.theatre.name"
+                    placeholder="{{object.name}}"
+                    value="{{object.flags.theatre.name}}"
+                />
             </div>
-            <div class="tab theatre-config-tab no-scrollbar" data-tab="emotes" data-group="theatre-tabs">
-                <div class="form-group"><label>{{localize "Theatre.UI.Config.DisableDefaultAnim"}}</label><input
-                        type="checkbox" name="flags.theatre.disabledefault" data-dtype="Boolean"
-                        {{checked object.flags.theatre.disabledefault}}="{{checked object.flags.theatre.disabledefault}}" />
-                    <p class="notes"> {{localize "Theatre.UI.Config.DisableDefaultAnimHint"}}</p>
-                </div>
-                <hr />
-                <h3 class="form-header"> {{localize "Theatre.UI.Config.ConfigureEmotes"}}</h3>
-                <p class="notes"> {{localize "Theatre.UI.Config.ConfigureEmotesHint"}}</p>
-                <div class="theatre-container-column emote-list">{{#each emote as |em key|}}
-                        {{#if em}}
-                            <div class="theatre-config-form-group" name="{{key}}">{{#if em.custom}}<label
-                                        class="theatre-config-emote-label customlabel"
-                                        data-edit="flags.theatre.emotes.{{key}}.label"
-                                        title="{{localize 'Theatre.UI.Title.ChooseEmoteName'}}">{{em.label}}
-                                        <div class="theatre-config-emote-label-dock"
-                                            title="{{localize 'Theatre.UI.Title.DeleteCustomEmote'}}"><i
-                                                class="fas fa-trash"></i></div>
-                                    </label>
-                                {{else}}<label class="theatre-config-emote-label"> {{em.label}}</label>{{/if}}
-                                <div class="theatre-emote-icon">{{#if em.image}}
-                                        {{#if em.custom}}<img class="customicon" src="{{em.image}}"
-                                                data-edit="flags.theatre.emotes.{{key}}.image"
-                                                title="{{localize 'Theatre.UI.Title.ChooseEmoteIcon'}}"
-                                                draggable="false" />
-                                        {{else}}<img src="{{em.image}}" draggable="false" />{{/if}}
-                                    {{else}}<i class="{{em.fatype}} {{em.faname}}"></i>{{/if}}</div>
-                                {{filePicker type="image" target=(cat (cat "flags.theatre.emotes." key) ".insert")}}<input
-                                    class="image" type="text" name="flags.theatre.emotes.{{key}}.insert"
-                                    placeholder="{{localize 'Theatre.UI.Config.PathPlaceholder'}}"
-                                    value="{{resprop (cat (cat 'object.flags.theatre.emotes.' key) '.insert')}}"
-                                    data-dtype="String" />
-                                <!--button.theatre-config-btn-edit-emote(type="button" name="{{key}}" title="{{localize 'Theatre.UI.Config.ConfigureEmote'}}")-->
-                                <!--i.fas.fa-sliders-h-->
-                            </div>
-                        {{/if}}
-                    {{/each}}<button class="theatre-config-btn-add-emote" type="button"
-                        name="add-emote">{{localize "Theatre.UI.Config.AddEmote"}}</button></div>
+            <p class="notes">{{localize "Theatre.UI.Config.SetTopAlign"}}</p>
+            <div class="form-group">
+                <select name="flags.theatre.optalign" data-dtype="String">
+                    {{selectOptions optalignChoices selected=object.flags.theatre.optalign localize=true}}
+                </select>
+            </div>
+            <p class="notes">{{localize "Theatre.UI.Config.SetDefaultInsert"}}</p>
+            <div class="form-group">
+                <label>{{localize "Theatre.UI.Config.BaseInsert"}}</label>
+                <file-picker name="flags.theatre.baseinsert" type="imagevideo" placeholder="{{object.img}}">{{object.flags.theatre.baseinsert}}</file-picker>
             </div>
         </section>
-        <button type="submit" name="submit"><i class="fas fa-save"></i>
-            {{localize "Theatre.UI.Config.SaveSettings"}}</button>
-    </div>
-</form>
+        <section
+            class="tab theatre-config-tab no-scrollbar {{tabs.emotes.id}} {{tabs.emotes.cssClass}}"
+            data-tab="{{tabs.emotes.id}}"
+            data-group="{{tabs.emotes.group}}"
+        >
+            <div class="form-group">
+                <label>{{localize "Theatre.UI.Config.DisableDefaultAnim"}}</label>
+                <input
+                    type="checkbox"
+                    name="flags.theatre.disabledefault"
+                    data-dtype="Boolean"
+                    {{checked
+                    object.flags.theatre.disabledefault}}="{{checked object.flags.theatre.disabledefault}}"
+                />
+                <p class="notes">{{localize "Theatre.UI.Config.DisableDefaultAnimHint"}}</p>
+            </div>
+            <hr />
+            <h3 class="form-header">{{localize "Theatre.UI.Config.ConfigureEmotes"}}</h3>
+            <p class="notes">{{localize "Theatre.UI.Config.ConfigureEmotesHint"}}</p>
+            <div class="theatre-container-column emote-list">
+                {{#each emote as |em key|}} {{#if em}}
+                <div class="theatre-config-form-group" name="{{key}}">
+                    {{#if em.custom}}
+                    <label
+                        class="theatre-config-emote-label customlabel"
+                        data-edit="flags.theatre.emotes.{{key}}.label"
+                        title="{{localize 'Theatre.UI.Title.ChooseEmoteName'}}"
+                    >
+                        {{em.label}}
+                        <div
+                            class="theatre-config-emote-label-dock"
+                            title="{{localize 'Theatre.UI.Title.DeleteCustomEmote'}}"
+                        >
+                            <i class="fas fa-trash"></i>
+                        </div>
+                    </label>
+                    {{else}}
+                    <label class="theatre-config-emote-label">{{em.label}}</label>
+                    {{/if}}
+                    <div class="theatre-emote-icon">
+                        {{#if em.image}} {{#if em.custom}}
+                        <img
+                            class="customicon"
+                            src="{{em.image}}"
+                            data-edit="flags.theatre.emotes.{{key}}.image"
+                            data-action="onCustomIconImage"
+                            title="{{localize 'Theatre.UI.Title.ChooseEmoteIcon'}}"
+                            draggable="false"
+                        />
+                        {{else}}
+                        <img src="{{em.image}}" draggable="false" />
+                        {{/if}} {{else}}
+                        <i class="{{em.fatype}} {{em.faname}}"></i>
+                        {{/if}}
+                    </div>
+                    <file-picker
+                        name="flags.theatre.emotes.{{key}}.insert"
+                        type="image"
+                        placeholder="{{localize 'Theatre.UI.Config.PathPlaceholder'}}"
+                    >{{resprop (cat (cat 'object.flags.theatre.emotes.' key) '.insert')}}</file-picker>
+                </div>
+                {{/if}} {{/each}}
+                <button
+                    class="theatre-config-btn-add-emote"
+                    type="button"
+                    name="add-emote"
+                    data-action="onAddEmoteLine"
+                >
+                    {{localize "Theatre.UI.Config.AddEmote"}}
+                </button>
+            </div>
+        </section>
+    </section>
+    <button type="submit" name="submit" class="theatre-config-btn-submit">
+        <i class="fas fa-save"></i>
+        {{localize "Theatre.UI.Config.SaveSettings"}}
+    </button>
+</div>


### PR DESCRIPTION
The major change is the file `src/scripts/TheatreActorConfig.js`. The rest of the changes are to remove the deprecation warnings:
- use chatMessage.author instead of chatMessage.user
- use foundry namespace instead of globals


It can be tested using this url to install the module:
```https://github.com/samulopez/fvtt-module-theatre/releases/latest/download/module.json```


There shouldn't be any visual changes apart from the file TheatreActorConfig, which will use the new foundry theme. 